### PR TITLE
fix the setps to start k8s with frakti

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Finally, start kubernetes with frakti runtime:
 ```sh
 cd $GOPATH/src/k8s.io/kubernetes
 export KUBERNETES_PROVIDER=local
+export CONTAINER_RUNTIME=remote
 export CONTAINER_RUNTIME_ENDPOINT=/var/run/frakti.sock
 hack/local-up-cluster.sh
 ```


### PR DESCRIPTION
Cause the code in k8s has changed, so update readme to fix the setps to start k8s with frakti.

Signed-off-by: Xianglin Gao <xlgao@zju.edu.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/frakti/32)
<!-- Reviewable:end -->
