### PR TITLE
Continue the loop on name parse error

### DIFF
--- a/pkg/hyper/container.go
+++ b/pkg/hyper/container.go
@@ -144,8 +144,8 @@ func (h *Runtime) ListContainers(filter *kubeapi.ContainerFilter) ([]*kubeapi.Co
 		_, _, _, containerName, attempt, err := parseContainerName(strings.Replace(c.ContainerName, "/", "", -1))
 
 		if err != nil {
-			glog.Errorf("ParseContainerName for %s failed: %v", c.ContainerName, err)
-			return nil, err
+			glog.V(3).Infof("ParseContainerName for %q failed (%v), assuming it is not managed by frakti", c.ContainerName, err)
+			continue
 		}
 
 		if filter != nil {

--- a/pkg/hyper/sandbox.go
+++ b/pkg/hyper/sandbox.go
@@ -159,8 +159,8 @@ func (h *Runtime) ListPodSandbox(filter *kubeapi.PodSandboxFilter) ([]*kubeapi.P
 
 		podName, podNamespace, podUID, attempt, err := parseSandboxName(pod.PodName)
 		if err != nil {
-			glog.Errorf("ParseSandboxName for %s failed: %v", pod.PodName, err)
-			return nil, err
+			glog.V(3).Infof("ParseSandboxName for %q failed (%v), assuming it is not managed by frakti", pod.PodName, err)
+			continue
 		}
 
 		if filter != nil {


### PR DESCRIPTION
Continue the loop on name parse error, assuming the errored container or sandbox is not managed by frakti.

Fixes #43.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/frakti/44)
<!-- Reviewable:end -->
