### PR TITLE
Return err only instead

### DIFF
--- a/pkg/hyper/client.go
+++ b/pkg/hyper/client.go
@@ -114,7 +114,7 @@ func (c *Client) StopPod(podID string) (int, string, error) {
 		PodID: podID,
 	})
 	if err != nil {
-		return int(resp.Code), resp.Cause, err
+		return 0, "", err
 	}
 
 	return int(resp.Code), resp.Cause, nil


### PR DESCRIPTION
resp is nil in grpc when there's error, this will cause nil pointer

cc @feiskyer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/frakti/45)
<!-- Reviewable:end -->
