### PR TITLE
Resource value has been fixed on upstream

### DIFF
--- a/pkg/hyper/helper.go
+++ b/pkg/hyper/helper.go
@@ -337,8 +337,6 @@ func getMemeoryLimitFromCgroup(cgroupParent string) (int32, error) {
 		return -1, err
 	}
 	cgroupPath := filepath.Join(mntPath, cgroupParent)
-	// TODO(harry) k8s does not forbidden illegal number e.g. `512m`, this will create a file with only `4096` bytes memory
-	// need to fix this on upstream.
 	memoryInBytes, err := readCgroupFileToInt64(cgroupPath, memoryCgroupFile)
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
Tested on latest k8s master, parameter like `512m` also works, it will be translated to `512M`.

Remove this outdated comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/frakti/48)
<!-- Reviewable:end -->
