### PR TITLE
Enable container volume for frakti

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -89,7 +89,7 @@ def file_passes(filename, refs, regexs):
         if p.search(d):
             return False
 
-    # Replace all occurrences of the regex "2016|2015|2014" with "YEAR"
+    # Replace all occurrences of the regex "2017|2016|2015|2014" with "YEAR"
     p = regexs["date"]
     for i, d in enumerate(data):
         (data[i], found) = p.subn('YEAR', d)
@@ -149,8 +149,8 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
-    # dates can be 2014, 2015 or 2016, company holder names can be anything
-    regexs["date"] = re.compile( '(2014|2015|2016)' )
+    # dates can be 2014, 2015, 2016 or 2017, company holder names can be anything
+    regexs["date"] = re.compile( '(2014|2015|2016|2017)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts

--- a/pkg/hyper/container.go
+++ b/pkg/hyper/container.go
@@ -18,12 +18,18 @@ package hyper
 
 import (
 	"fmt"
+	"math/rand"
+	"path/filepath"
 	"strings"
 
 	"github.com/golang/glog"
 
 	"k8s.io/frakti/pkg/hyper/types"
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+const (
+	volDriver = "vfs"
 )
 
 // CreateContainer creates a new container in specified PodSandbox
@@ -60,18 +66,27 @@ func buildUserContainer(config *kubeapi.ContainerConfig, sandboxConfig *kubeapi.
 		Labels:     buildLabelsWithAnnotations(config.Labels, config.Annotations),
 	}
 
-	// TODO: support adding device in upstream hyperd when creating container.
+	// make volumes
+	volumes := make([]*types.UserVolumeReference, len(config.Mounts))
+	for i, m := range config.Mounts {
+		hostPath := m.GetHostPath()
+		_, volName := filepath.Split(hostPath)
+		volDetail := &types.UserVolume{
+			Name: volName + fmt.Sprintf("_%08x", rand.Uint32()),
+			// kuberuntime will set HostPath to the abs path of volume directory on host
+			Source: hostPath,
+			Format: volDriver,
+		}
+		volumes[i] = &types.UserVolumeReference{
+			// use the generated volume name above
+			Volume:   volDetail.Name,
+			Path:     m.GetContainerPath(),
+			ReadOnly: m.GetReadonly(),
+			Detail:   volDetail,
+		}
+	}
 
-	// TODO: support volume mounts in upstream hyperd.
-	// volumes := make([]*types.UserVolumeReference, len(config.Mounts))
-	// for idx, v := range config.Mounts {
-	// 	volumes[idx] = &types.UserVolumeReference{
-	// 		Volume:   v.GetHostPath(),
-	// 		Path:     v.GetContainerPath(),
-	// 		ReadOnly: v.GetReadonly(),
-	// 	}
-	// }
-	containerSpec.Volumes = []*types.UserVolumeReference{}
+	containerSpec.Volumes = volumes
 
 	// make environments
 	environments := make([]*types.EnvironmentVar, len(config.Envs))

--- a/pkg/hyper/container.go
+++ b/pkg/hyper/container.go
@@ -67,6 +67,7 @@ func buildUserContainer(config *kubeapi.ContainerConfig, sandboxConfig *kubeapi.
 	}
 
 	// make volumes
+	// TODO: support adding device in upstream hyperd when creating container.
 	volumes := make([]*types.UserVolumeReference, len(config.Mounts))
 	for i, m := range config.Mounts {
 		hostPath := m.GetHostPath()

--- a/pkg/hyper/types/types.pb.go
+++ b/pkg/hyper/types/types.pb.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/images.go
+++ b/test/e2e/images.go
@@ -161,7 +161,7 @@ var _ = framework.KubeDescribe("Test image", func() {
 		// different tags refer to the same image
 		testImageList := []string{
 			"busybox:1",
-			"busybox:1.25",
+			"busybox:1-uclibc",
 			"busybox:uclibc",
 		}
 


### PR DESCRIPTION
1. Generate `volDetail` based on Mounts
2. Generate `UserVolumeReference` for container spec
3. Add e2e test for volume container

NOTE: This can not work unless workaround https://github.com/hyperhq/hyperd/issues/487 ( for example, remove volume Validate(), will also fix it soon)