### PR TITLE
Check the response of PodRemove

### DIFF
--- a/pkg/hyper/client.go
+++ b/pkg/hyper/client.go
@@ -135,12 +135,11 @@ func (c *Client) RemovePod(podID string) error {
 		ctx,
 		&types.PodRemoveRequest{PodID: podID},
 	)
-
-	if resp.Code == errorCodePodNotFound {
-		return nil
-	}
-
 	if err != nil {
+		if resp != nil && resp.Code == errorCodePodNotFound {
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Check the response of `hyper.PodRemove` and fix potential panic.