### PR TITLE
Avoid panic when labels are nil

### DIFF
--- a/pkg/hyper/helper.go
+++ b/pkg/hyper/helper.go
@@ -187,13 +187,18 @@ func buildLabelsWithAnnotations(labels, annotations map[string]string) map[strin
 		return labels
 	}
 
+	newLables := labels
+	if labels == nil {
+		newLables = make(map[string]string)
+	}
+
 	rawAnnotations, err := json.Marshal(annotations)
 	if err != nil {
 		glog.Warningf("Unable to marshal annotations %q: %v", annotations, err)
 	}
 
-	labels[fraktiAnnotationLabel] = string(rawAnnotations)
-	return labels
+	newLables[fraktiAnnotationLabel] = string(rawAnnotations)
+	return newLables
 }
 
 // getAnnotationsFromLabels gets annotations from labels.


### PR DESCRIPTION
Frakti will panic, when we annotation is not nil but labels are nil.

/cc @feiskyer 

Signed-off-by: Xianglin Gao <xlgao@zju.edu.cn>