### PR TITLE
Filter CodeExitError type error in Exec streaming API

### DIFF
--- a/pkg/hyper/client.go
+++ b/pkg/hyper/client.go
@@ -570,7 +570,7 @@ func (c *Client) ExecInContainer(containerId string, cmd []string, stdin io.Read
 		return err
 	}
 
-	return utilexec.CodeExitError{Err: nil, Code: int(exitCode)}
+	return utilexec.CodeExitError{Err: fmt.Errorf("Exit with code %d", exitCode), Code: int(exitCode)}
 }
 
 // Wait gets exit code by containerID and execID

--- a/pkg/hyper/streaming.go
+++ b/pkg/hyper/streaming.go
@@ -27,6 +27,7 @@ import (
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
 	"k8s.io/kubernetes/pkg/kubelet/util/ioutils"
+	utilexec "k8s.io/kubernetes/pkg/util/exec"
 )
 
 type streamingRuntime struct {
@@ -42,7 +43,11 @@ func (sr *streamingRuntime) Exec(rawContainerID string, cmd []string, stdin io.R
 	if err != nil {
 		return err
 	}
-	return sr.client.ExecInContainer(rawContainerID, cmd, stdin, stdout, stderr, tty, resize, 0)
+	err = sr.client.ExecInContainer(rawContainerID, cmd, stdin, stdout, stderr, tty, resize, 0)
+	if _, ok := err.(utilexec.CodeExitError); ok {
+		return nil
+	}
+	return err
 }
 
 // Attach attach to a running container.


### PR DESCRIPTION
close #134 
```
# crictl info
Version:  0.1.0
RuntimeName:  hyper
RuntimeVersion:  0.8.1
RuntimeApiVersion:  0.1.0
# crictl exec -i -t 65c58ed5a447e67f887d9ac285a8f239670bce9ef8cd4f6655e8fdc7ba113845 sh
/ # ls
ls
bin   dev   etc   home  lib   proc  root  sys   tmp   usr   var
/ # exit
exit
```
/cc @feiskyer 

Signed-off-by: Crazykev <crazykev@zju.edu.cn>