### PR TITLE
Make default cpu and memory configurable

### DIFF
--- a/cmd/frakti/frakti.go
+++ b/cmd/frakti/frakti.go
@@ -58,6 +58,8 @@ var (
 	enableAlternativeRuntime = pflag.Bool("enable-alternative-runtime", true, "Enable alternative runtime to handle OS containers, default is true")
 	cgroupDriver             = pflag.String("cgroup-driver", "cgroupfs", "Driver that the frakti uses to manipulate cgroups on the host. *SHOULD BE SAME AS* kubelet cgroup driver configuration.  Possible values: 'cgroupfs', 'systemd'")
 	rootDir                  = pflag.String("root-directory", "/var/lib/frakti", "Path to the frakti root directory")
+	defaultCPUNum            = pflag.Int32("cpu", 1, "Default CPU in number for HyperVM when cpu limit is not specified for the pod")
+	defaultMemoryMB          = pflag.Int32("memory", 64, "Default memory in MB for HyperVM when memory limit is not specified for the pod")
 )
 
 func main() {
@@ -77,7 +79,7 @@ func main() {
 
 	// 1. Initialize hyper runtime and streaming server
 	streamingConfig := getStreamingConfig()
-	hyperRuntime, streamingServer, err := hyper.NewHyperRuntime(*hyperEndpoint, streamingConfig, *cniNetDir, *cniPluginDir, *rootDir)
+	hyperRuntime, streamingServer, err := hyper.NewHyperRuntime(*hyperEndpoint, streamingConfig, *cniNetDir, *cniPluginDir, *rootDir, *defaultCPUNum, *defaultMemoryMB)
 	if err != nil {
 		glog.Errorf("Initialize hyper runtime failed: %v", err)
 		os.Exit(1)

--- a/pkg/hyper/helper.go
+++ b/pkg/hyper/helper.go
@@ -45,10 +45,6 @@ const (
 
 	containerLogPathLabelKey = "io.kubernetes.container.logpath"
 
-	// default resources while the pod level qos of kubelet pod is not specified.
-	defaultCPUNumber         = 1
-	defaultMemoryinMegabytes = 64
-
 	// More details about these: http://kubernetes.io/docs/user-guide/compute-resources/
 	// cpuQuotaCgroupFile is the `cfs_quota_us` value set by kubelet pod qos
 	cpuQuotaCgroupFile = "cpu.cfs_quota_us"
@@ -299,7 +295,7 @@ func toKubeContainerState(state string) kubeapi.ContainerState {
 
 // TODO(harry) These two methods will find subsystem mount point frequently, consider move FindCgroupMountpoint into a unified place.
 // getCpuLimitFromCgroup get the cpu limit from given cgroupParent
-func getCpuLimitFromCgroup(cgroupParent string) (int32, error) {
+func (h *Runtime) getCpuLimitFromCgroup(cgroupParent string) (int32, error) {
 	mntPath, err := libcontainercgroups.FindCgroupMountpoint("cpu")
 	if err != nil {
 		return -1, err
@@ -320,8 +316,8 @@ func getCpuLimitFromCgroup(cgroupParent string) (int32, error) {
 
 	// This is needed when pod is burstable but no cpu limit is set, then cpuQuota will be -1, hyperCPUNumber
 	// will be calculate to 0
-	if hyperCPUNumber < defaultCPUNumber {
-		hyperCPUNumber = defaultCPUNumber
+	if hyperCPUNumber < h.defaultCPUNum {
+		hyperCPUNumber = h.defaultCPUNum
 	}
 
 	return hyperCPUNumber, nil
@@ -342,7 +338,7 @@ func readCgroupFileToInt64(cgroupPath, cgroupFile string) (int64, error) {
 }
 
 // getMemeoryLimitFromCgroup get the memory limit from given cgroupParent
-func getMemeoryLimitFromCgroup(cgroupParent string) (int32, error) {
+func (h *Runtime) getMemeoryLimitFromCgroup(cgroupParent string) (int32, error) {
 	mntPath, err := libcontainercgroups.FindCgroupMountpoint("memory")
 	if err != nil {
 		return -1, err
@@ -358,8 +354,8 @@ func getMemeoryLimitFromCgroup(cgroupParent string) (int32, error) {
 	// HyperContainer requires at least 64Mi memory
 	// And this also protect when pod is burstable but no memory limit is set,
 	// then frakti will read a illegal (larger than int32) value and got memoryinMegabytes < 0
-	if memoryinMegabytes < defaultMemoryinMegabytes {
-		memoryinMegabytes = defaultMemoryinMegabytes
+	if memoryinMegabytes < h.defaultMemoryMB {
+		memoryinMegabytes = h.defaultMemoryMB
 	}
 	return memoryinMegabytes, nil
 }

--- a/pkg/hyper/hyper.go
+++ b/pkg/hyper/hyper.go
@@ -42,10 +42,13 @@ type Runtime struct {
 	streamingServer   streaming.Server
 	netPlugin         ocicni.CNIPlugin
 	checkpointHandler CheckpointHandler
+
+	defaultCPUNum   int32
+	defaultMemoryMB int32
 }
 
 // NewHyperRuntime creates a new Runtime
-func NewHyperRuntime(hyperEndpoint string, streamingConfig *streaming.Config, cniNetDir, cniPluginDir, rootDir string) (*Runtime, streaming.Server, error) {
+func NewHyperRuntime(hyperEndpoint string, streamingConfig *streaming.Config, cniNetDir, cniPluginDir, rootDir string, defaultCPUNum, defaultMemoryMB int32) (*Runtime, streaming.Server, error) {
 	hyperClient, err := NewClient(hyperEndpoint, hyperConnectionTimeout)
 	if err != nil {
 		glog.Fatalf("Initialize hyper client failed: %v", err)
@@ -76,6 +79,8 @@ func NewHyperRuntime(hyperEndpoint string, streamingConfig *streaming.Config, cn
 		streamingServer:   streamingServer,
 		netPlugin:         netPlugin,
 		checkpointHandler: persistentCheckpointHandler,
+		defaultCPUNum:     defaultCPUNum,
+		defaultMemoryMB:   defaultMemoryMB,
 	}
 
 	return rt, streamingServer, nil


### PR DESCRIPTION
In some cases, the default 64MB memory is not sufficient. This PR makes the default cpu and memory configurable.

It should help with rook.io (#151) with setting default memory to 512MB.