### PR TITLE
Fix version

### DIFF
--- a/cmd/frakti/frakti.go
+++ b/cmd/frakti/frakti.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	fraktiVersion = "0.1"
+	fraktiVersion = "0.2"
 
 	// use port 22522 for dockershim streaming
 	alternativeStreamingServerPort = 22522


### PR DESCRIPTION
Frakti v0.2 has been already released, but its version number is still old. This PR updates frakti version to 0.2.

Fixes #163.