### PR TITLE
Use kubernetes stable version in deploy guide

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -217,7 +217,7 @@ systemctl daemon-reload
 ### Setting up the master node
 
 ```sh
-kubeadm init --pod-network-cidr 10.244.0.0/16 --kubernetes-version latest
+kubeadm init --pod-network-cidr 10.244.0.0/16 --kubernetes-version stable
 ```
 
 Optional: enable schedule pods on the master


### PR DESCRIPTION
Refer https://github.com/kubernetes/frakti/issues/173#issuecomment-309949774.

kubeadm v1.6 doesn't support deploying v1.7 clusters well, we should recommend stable version in our docs.