### PR TITLE
Bump frakti to version 1.0

### DIFF
--- a/cmd/frakti/frakti.go
+++ b/cmd/frakti/frakti.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	fraktiVersion = "0.3"
+	fraktiVersion = "1.0"
 
 	// use port 22522 for dockershim streaming
 	alternativeStreamingServerPort = 22522

--- a/pkg/hyper/hyper.go
+++ b/pkg/hyper/hyper.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	hyperRuntimeName    = "hyper"
-	minimumHyperVersion = "0.6.0"
+	minimumHyperVersion = "0.8.1"
 	secondToNano        = 1e9
 
 	// timeout in second for interacting with hyperd's gRPC API.


### PR DESCRIPTION
For #183. 

Bump frakti to version 1.0 and hyperd minversion to 0.8.1.

