### PR TITLE
ignore some error messages

### DIFF
--- a/pkg/hyper/ocicni/ocicni.go
+++ b/pkg/hyper/ocicni/ocicni.go
@@ -209,6 +209,10 @@ func (network *cniNetwork) deleteFromNetwork(podNetnsPath string, podID string, 
 	glog.V(4).Infof("About to del CNI network %v (type=%v)", netConf.Name, netConf.Plugins[0].Network.Type)
 	err = cniNet.DelNetworkList(netConf, rt)
 	if err != nil {
+		// ignore the error that ns has already not existed
+		if strings.Contains(err.Error(), "no such file or directory") {
+			return nil
+		}
 		glog.Errorf("Pod: %s, Netns: %s, Error deleting network: %v", podID, podNetnsPath, err)
 		return err
 	}


### PR DESCRIPTION
Ignore the error that netns or bridge not exist, when kubelet stop pod multiple times.

Also move RemoveCheckpoint() after teardownRelayBridgeInHost()
in case it get error and return immediately without delete the relay bridge in host.
