### PR TITLE
Deploy flexvolume by DaemonSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,4 @@ network_closure.sh
 # binaries
 out
 cmd/protoc-gen-gogo/protoc-gen-gogo
-
+deployment/flexvolume/flexvolume_driver

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ frakti: $(shell $(LOCALKUBEFILES))
 	go build -a -o ${BUILD_DIR}/frakti ./cmd/frakti
 	go build -a -o ${BUILD_DIR}/flexvolume_driver ./cmd/flexvolume_driver
 
+.PHONY: docker
+docker:
+	cp ${BUILD_DIR}/flexvolume_driver deployment/flexvolume/
+	sudo docker build -t stackube/flex-volume:v1.0 deployment/flexvolume/
+
 .PHONY: install
 install:
 	cp -f ./out/frakti /usr/bin

--- a/deployment/flexvolume/Dockerfile
+++ b/deployment/flexvolume/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.6
+
+MAINTAINER frakti team
+
+# add bash
+RUN apk --no-cache add bash
+
+WORKDIR /flexvolume
+ 
+COPY flexvolume_driver .
+COPY cinder.conf.default cinder.conf.tmp
+COPY install.sh .

--- a/deployment/flexvolume/cinder.conf.default
+++ b/deployment/flexvolume/cinder.conf.default
@@ -1,0 +1,8 @@
+[Global]
+auth-url = _AUTH_URL_
+username = _USERNAME_
+password = _PASSWORD_
+tenant-name = _TENAN_TNAME_
+region = _REGION_
+[RBD]
+keyring = _KEYRING_

--- a/deployment/flexvolume/flexvolume-configmap.yaml
+++ b/deployment/flexvolume/flexvolume-configmap.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: flexvolume-config
+  namespace: kube-system
+data:
+  auth-url: "https://${SERVICE_HOST}/identity_admin/v2.0"
+  username: "admin"
+  password: "${ADMIN_PASSWORD}"
+  tenant-name: "admin"
+  region: "RegionOne"
+  keyring: "${KEYRING}"

--- a/deployment/flexvolume/flexvolume-ds.yaml
+++ b/deployment/flexvolume/flexvolume-ds.yaml
@@ -1,0 +1,85 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: cinder-flexvolume
+  namespace: kube-system
+  labels:
+    component: cinder-flexvolume
+    k8s-app: cinder-flexvolume
+    name: cinder-flexvolume
+spec:
+  selector:
+    matchLabels:
+      component: cinder-flexvolume
+      k8s-app: cinder-flexvolume
+      name: cinder-flexvolume
+  template:
+    metadata:
+      labels:
+        component: cinder-flexvolume
+        k8s-app: cinder-flexvolume
+        name: cinder-flexvolume
+      annotations:
+        runtime.frakti.alpha.kubernetes.io/OSContainer: "true"
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      securityContext: {}
+      containers:
+        - name: cinder-flexvolume
+          resources: {}
+          image: stackube/flex-volume:v1.0
+          command: ["/bin/bash", "install.sh"]
+          env:
+            # The endpoint of openstack authentication.
+            - name: AUTH_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: flexvolume-config
+                  key: auth-url
+            # The username for openstack authentication.
+            - name: USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: flexvolume-config
+                  key: username
+            # The password for openstack authentication.
+            - name: PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: flexvolume-config
+                  key: password
+            # The tenant name for openstack authentication.
+            - name: TENANT_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: flexvolume-config
+                  key: tenant-name
+            # The region for openstack authentication.
+            - name: REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: flexvolume-config
+                  key: region
+            # The keyring for cinder client.
+            - name: KEYRING
+              valueFrom:
+                configMapKeyRef:
+                  name: flexvolume-config
+                  key: keyring
+          volumeMounts:
+            - mountPath: /mnt/binary
+              name: binarydir
+            - mountPath: /mnt/config
+              name: cinderconfig
+      volumes:
+        # Used for flexvolume binary.
+        - name: binarydir
+          hostPath:
+            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/cinder~flexvolume_driver/
+        # Used to cinder client.
+        - name: cinderconfig
+          hostPath:
+            path: /etc/kubernetes

--- a/deployment/flexvolume/install.sh
+++ b/deployment/flexvolume/install.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# gracefully handle the TERM signal sent when deleting the daemonset
+trap 'exit' TERM
+
+# WORKDIR /flexvolume
+TMP_CONF='cinder.conf.tmp'
+VOL_BINARY='flexvolume_driver'
+
+VOL_BINARY_DIR='/mnt/binary'
+
+# Check environment variables before any real actions.
+for var in 'AUTH_URL' 'USERNAME' 'PASSWORD' 'TENANT_NAME' 'REGION' 'KEYRING';do
+	if [ "${!var}" ];then
+		echo "environment variable $var = ${!var}"
+	else
+		echo "environment variable $var is empty, exit..."
+		exit 1
+	fi
+done
+
+# Insert parameters.
+sed -i s~_AUTH_URL_~${AUTH_URL:-}~g ${TMP_CONF}
+sed -i s/_USERNAME_/${USERNAME:-}/g ${TMP_CONF}
+sed -i s/_PASSWORD_/${PASSWORD:-}/g ${TMP_CONF}
+sed -i s/_TENANT_NAME_/${TENANT_NAME:-}/g ${TMP_CONF}
+sed -i s/_REGION_/${REGION:-}/g ${TMP_CONF}
+sed -i s/_KEYRING_/${KEYRING:-}/g ${TMP_CONF}
+
+# Move the temporary Cinder config into place.
+CINDER_CONFIG_FIlE='/mnt/config/cinder.conf'
+mv ${TMP_CONF} ${CINDER_CONFIG_FIlE}
+mv ${VOL_BINARY} ${VOL_BINARY_DIR}
+
+echo "Successfully installed flexvolume!" 
+
+# this is a workaround to prevent the container from exiting 
+# and k8s restarting the daemonset pod
+while true; do sleep 1; done

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -271,3 +271,10 @@ ip route add 10.244.3.0/24 via 10.140.0.3
 ip route add 10.244.1.0/24 via 10.140.0.1
 ip route add 10.244.2.0/24 via 10.140.0.2
 ```
+
+## Use `frakti` in production environment
+In a production environment, we recommend user to have their own CNI plugin (Flannel, Calico, Neutron etc), and persistent volume provider (GlusterFS, Cephfs, NFS etc). Please follow Kubernetes admin doc for  details about integration, and it makes no difference if you are using `frakti`.
+
+On the other hand, https://github.com/openstack/stackube is a production ready upstream Kubernetes cluster with `frakti` as container runtime, standalone Neutron, Cinder and Keystone to provide multi-tenancy, networking and storage. Please feel free to explore.
+
+And, if you would like to try `frakti` with more integrations in your own environment, contribution will always be appreciated!


### PR DESCRIPTION
Workflow (This will be added to Stackube after this PR is merged):

```shell
    cat >flexvolume-configmap.yaml <<EOF
kind: ConfigMap
apiVersion: v1
metadata:
  name: flexvolume-config
  namespace: kube-system
data:
  auth-url: "https://${SERVICE_HOST}/identity_admin/v2.0"
  username: "admin"
  password: "${ADMIN_PASSWORD}"
  tenant-name: "admin"
  region: "RegionOne"
EOF
    kubectl create -f flexvolume-configmap.yaml
    kubectl create -f ${FRAKTI_ROOT}/deployment/flexvolume/flexvolume-ds.yaml
```

The `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/cinder~flexvolume_driver/` should be created automatically with binary inside.

And `/etc/kubernetes/cinder` should have also be created with right content.

