### PR TITLE
Support weave network plugin

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -5,6 +5,7 @@ Frakti is using CNI for setting up pod's networking. A list of validated plugins
 - Bridge
 - Flannel
 - Calico
+- Weave
 
 ## [Bridge](https://github.com/containernetworking/plugins/tree/master/plugins/main/bridge)
 
@@ -82,4 +83,18 @@ Then setup calico plugin by running:
 
 ```sh
 kubectl apply -f https://docs.projectcalico.org/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+```
+
+## [Weave](https://www.weave.works/)
+
+Remove other cni network configure if they are already configured:
+
+```sh
+rm -f /etc/cni/net.d/*
+```
+
+Then setup weave plugin by running:
+
+```sh
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
 ```

--- a/pkg/hyper/helper.go
+++ b/pkg/hyper/helper.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hyper
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -412,4 +414,11 @@ func isPodNotFoundError(err error, podID string) bool {
 		}
 	}
 	return false
+}
+
+// getMD5Hash gets the md5 hash for the text.
+func getMD5Hash(text string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(text))
+	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/pkg/hyper/ocicni/ocicni.go
+++ b/pkg/hyper/ocicni/ocicni.go
@@ -153,7 +153,11 @@ func (plugin *cniNetworkPlugin) checkInitialized() error {
 }
 
 func (plugin *cniNetworkPlugin) Name() string {
-	return CNIPluginName
+	if err := plugin.checkInitialized(); err != nil {
+		return CNIPluginName
+	}
+
+	return plugin.getDefaultNetwork().name
 }
 
 func (plugin *cniNetworkPlugin) SetUpPod(podNetnsPath string, podID string, metadata *kubeapi.PodSandboxMetadata, annotations map[string]string, capabilities map[string]interface{}) (cnitypes.Result, error) {

--- a/pkg/hyper/sandbox.go
+++ b/pkg/hyper/sandbox.go
@@ -77,7 +77,12 @@ func (h *Runtime) RunPodSandbox(config *kubeapi.PodSandboxConfig) (string, error
 		"portMappings": portMappingsParam,
 	}
 	podId := userpod.Id
-	_, err = h.netPlugin.SetUpPod(netNsPath, podId, config.GetMetadata(), config.GetAnnotations(), capabilities)
+	sandboxID := podId
+	// workaroud for weave network plugin because it creates a veth pair based on a truncated sandboxID.
+	if h.netPlugin.Name() == "weave" {
+		sandboxID = getMD5Hash(podId)
+	}
+	_, err = h.netPlugin.SetUpPod(netNsPath, sandboxID, config.GetMetadata(), config.GetAnnotations(), capabilities)
 	if err != nil {
 		glog.Errorf("Setup network for sandbox %q by cni plugin failed: %v", config.String(), err)
 		return "", err
@@ -85,7 +90,7 @@ func (h *Runtime) RunPodSandbox(config *kubeapi.PodSandboxConfig) (string, error
 	defer func() {
 		if err != nil {
 			// tear down sandbox's network
-			teardownError := h.netPlugin.TearDownPod(netNsPath, podId, config.GetMetadata(), config.GetAnnotations(), capabilities)
+			teardownError := h.netPlugin.TearDownPod(netNsPath, sandboxID, config.GetMetadata(), config.GetAnnotations(), capabilities)
 			if teardownError != nil {
 				glog.Errorf("Tear down network for pod %s failed: %v", podId, teardownError)
 			}
@@ -291,7 +296,12 @@ func (h *Runtime) StopPodSandbox(podSandboxID string) error {
 	}
 
 	// 4: tear down the cni network.
-	err = h.netPlugin.TearDownPod(netNsPath, podSandboxID, status.GetMetadata(), status.GetAnnotations(), capabilities)
+	sandboxID := podSandboxID
+	// workaroud for weave network plugin because it creates a veth pair based on a truncated sandboxID.
+	if h.netPlugin.Name() == "weave" {
+		sandboxID = getMD5Hash(podSandboxID)
+	}
+	err = h.netPlugin.TearDownPod(netNsPath, sandboxID, status.GetMetadata(), status.GetAnnotations(), capabilities)
 	if err != nil {
 		return fmt.Errorf("error of teardown network for sandbox %q: %v", podSandboxID, err)
 	}


### PR DESCRIPTION
Fix #216.

To use weave network plugin, run

```sh
  kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
```