### PR TITLE
Enable unikernel runtime log

### DIFF
--- a/cmd/frakti/frakti.go
+++ b/cmd/frakti/frakti.go
@@ -58,6 +58,7 @@ var (
 		"The endpoint of privileged runtime to communicate with")
 	enablePrivilegedRuntime = pflag.Bool("enable-privileged-runtime", true, "Enable privileged runtime to handle OS containers, default is true")
 	enableUnikernelRuntime  = pflag.Bool("enable-unikernel-runtime", false, "Enable unikernel runtime to run containers using unikernel image, default is false. Still under development.")
+	enableUnikernelLog      = pflag.Bool("enable-unikernel-log", true, "Enable unikernel runtime's log allow print VM's log to kubelet specified file, while disable some ability when `virsh console` to VM.")
 	cgroupDriver            = pflag.String("cgroup-driver", "cgroupfs", "Driver that the frakti uses to manipulate cgroups on the host. *SHOULD BE SAME AS* kubelet cgroup driver configuration.  Possible values: 'cgroupfs', 'systemd'")
 	rootDir                 = pflag.String("root-directory", "/var/lib/frakti", "Path to the frakti root directory")
 	defaultCPUNum           = pflag.Int32("cpu", 1, "Default CPU in number for HyperVM when cpu limit is not specified for the pod")
@@ -104,7 +105,7 @@ func main() {
 	// 3. Initialize unikernel runtime if enabled
 	var unikernelRuntime *unikernel.UnikernelRuntime
 	if *enableUnikernelRuntime {
-		unikernelRuntime, err = unikernel.NewUnikernelRuntimeService(*cniNetDir, *cniPluginDir, *rootDir, *defaultCPUNum, *defaultMemoryMB)
+		unikernelRuntime, err = unikernel.NewUnikernelRuntimeService(*cniNetDir, *cniPluginDir, *rootDir, *defaultCPUNum, *defaultMemoryMB, *enableUnikernelLog)
 		if err != nil {
 			glog.Errorf("Initialize unikernel runtime failed: %v", err)
 			os.Exit(1)

--- a/pkg/unikernel/libvirt/libvirt_domain.go
+++ b/pkg/unikernel/libvirt/libvirt_domain.go
@@ -54,14 +54,15 @@ func (lc *LibvirtConnect) DefineDomain(dxml *libvirtxml.Domain) (*LibvirtDomain,
 }
 
 // ListDomains get all domains managed by libvirt, including those not managed by unikernel runtime.
-func (lc *LibvirtConnect) ListDomains() ([]LibvirtDomain, error) {
+func (lc *LibvirtConnect) ListDomains() ([]*LibvirtDomain, error) {
 	domains, err := lc.conn.ListAllDomains(0)
 	if err != nil {
 		return nil, err
 	}
-	ldomains := make([]LibvirtDomain, len(domains))
+	ldomains := make([]*LibvirtDomain, len(domains))
 	for n, d := range domains {
-		ldomains[n] = LibvirtDomain{&d}
+		current := d
+		ldomains[n] = &LibvirtDomain{&current}
 	}
 	return ldomains, nil
 }

--- a/pkg/unikernel/libvirt/libvirt_domain_unsupported.go
+++ b/pkg/unikernel/libvirt/libvirt_domain_unsupported.go
@@ -38,7 +38,7 @@ func (lc *LibvirtConnect) DefineDomain(dxml *libvirtxml.Domain) (*LibvirtDomain,
 }
 
 // ListDomains get all domains managed by libvirt, including those not managed by unikernel runtime.
-func (lc *LibvirtConnect) ListDomains() ([]LibvirtDomain, error) {
+func (lc *LibvirtConnect) ListDomains() ([]*LibvirtDomain, error) {
 	return nil, fmt.Errorf("not supported")
 }
 

--- a/pkg/unikernel/libvirt/vmtools.go
+++ b/pkg/unikernel/libvirt/vmtools.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -37,12 +38,14 @@ const (
 )
 
 type VMTool struct {
-	conn *LibvirtConnect
+	conn      *LibvirtConnect
+	enableLog bool
 }
 
-func NewVMTool(conn *LibvirtConnect) *VMTool {
+func NewVMTool(conn *LibvirtConnect, enableLog bool) *VMTool {
 	return &VMTool{
-		conn: conn,
+		conn:      conn,
+		enableLog: enableLog,
 	}
 }
 
@@ -58,6 +61,7 @@ type VMSetting struct {
 	vcpuNum    int
 	memory     int
 	image      string
+	logPath    string
 }
 
 // NOTE(Crazykev): This method may be changed when support multiple container per Pod.
@@ -70,11 +74,22 @@ func (vt *VMTool) CreateContainer(ctrMeta *metadata.ContainerMetadata, sbMeta *m
 		memory:     int(sbMeta.VMConfig.Memory),
 		image:      ctrMeta.ImageRef,
 		enableKVM:  enableKVM(),
+		logPath:    filepath.Join(sbMeta.LogDir, ctrMeta.LogPath),
 	}
+
+	// Make sure log directory exist
+	// FIXME(Crazykev): Is kubelet's responsiblity to clean up the log directory?
+	if err := os.MkdirAll(filepath.Dir(settings.logPath), 0644); err != nil {
+		return fmt.Errorf("failed create log directory %q", settings.logPath)
+	}
+
 	domainxml, err := vt.createDomain(&settings)
 	if err != nil {
 		return fmt.Errorf("failed to create domain with config(%v): %v", settings, err)
 	}
+
+	// Append serial devices to domain
+	vt.appendSerialDevices(domainxml, &settings)
 
 	if _, err = vt.conn.DefineDomain(domainxml); err != nil {
 		return err
@@ -385,4 +400,29 @@ func (vt *VMTool) createDomain(setting *VMSetting) (*libvirtxml.Domain, error) {
 		}
 	}
 	return domain, nil
+}
+
+func (vt *VMTool) appendSerialDevices(domain *libvirtxml.Domain, settings *VMSetting) {
+	serialPort := uint(0)
+	if vt.enableLog {
+		domain.Devices.Serials = []libvirtxml.DomainSerial{
+			{
+				Type: "file", Target: &libvirtxml.DomainSerialTarget{Port: &serialPort},
+				Source: &libvirtxml.DomainChardevSource{Path: settings.logPath},
+			},
+		}
+		domain.Devices.Consoles = []libvirtxml.DomainConsole{
+			{
+				Type: "file", Target: &libvirtxml.DomainConsoleTarget{Type: "serial", Port: &serialPort},
+				Source: &libvirtxml.DomainChardevSource{Path: settings.logPath},
+			},
+		}
+	} else {
+		domain.Devices.Serials = []libvirtxml.DomainSerial{
+			{Type: "pty", Target: &libvirtxml.DomainSerialTarget{Port: &serialPort}},
+		}
+		domain.Devices.Consoles = []libvirtxml.DomainConsole{
+			{Type: "pty", Target: &libvirtxml.DomainConsoleTarget{Type: "serial", Port: &serialPort}},
+		}
+	}
 }

--- a/pkg/unikernel/libvirt/vmtools.go
+++ b/pkg/unikernel/libvirt/vmtools.go
@@ -361,6 +361,9 @@ func (vt *VMTool) createDomain(setting *VMSetting) (*libvirtxml.Domain, error) {
 				{Name: "rtc", Track: "guest", Tickpolicy: "catchup"},
 			},
 		},
+		Features: &libvirtxml.DomainFeatureList{
+			ACPI: &libvirtxml.DomainFeature{},
+		},
 		Devices: &libvirtxml.DomainDeviceList{
 			Emulator: emulator,
 			Inputs: []libvirtxml.DomainInput{
@@ -383,6 +386,15 @@ func (vt *VMTool) createDomain(setting *VMSetting) (*libvirtxml.Domain, error) {
 					Address: &libvirtxml.DomainAddress{Type: "pci", Domain: &imageDiskDomainIndex,
 						Bus: &imageDiskBusIndex, Slot: &imageDiskSlotIndex},
 				},
+			},
+			// configure for default nat network
+			/*
+				Interfaces: []libvirtxml.DomainInterface{
+					{Type: "network", Source: &libvirtxml.DomainInterfaceSource{Network: "default"}},
+				},
+			*/
+			Interfaces: []libvirtxml.DomainInterface{
+				{Type: "bridge", Source: &libvirtxml.DomainInterfaceSource{Bridge: "virbr0"}, Model: &libvirtxml.DomainInterfaceModel{Type: "virtio"}},
 			},
 		},
 		OnPoweroff: "destroy",

--- a/pkg/unikernel/metadata/container.go
+++ b/pkg/unikernel/metadata/container.go
@@ -48,6 +48,8 @@ type ContainerMetadata struct {
 	// Human-readable message indicating details about why container is in its
 	// current state.
 	Message string
+	// LogPath is path relative to sandbox's log directory for container to store logs.
+	LogPath string
 }
 
 // State returns current state of the container based on the metadata.

--- a/pkg/unikernel/metadata/sandbox.go
+++ b/pkg/unikernel/metadata/sandbox.go
@@ -39,6 +39,8 @@ type SandboxMetadata struct {
 	VMConfig *VMMetadata
 	// State is CRI state of sandbox
 	State kubeapi.PodSandboxState
+	// LogDir is where sandbox's log stores.
+	LogDir string
 }
 
 // VMMetadata is the vm metadata.

--- a/pkg/unikernel/service/container.go
+++ b/pkg/unikernel/service/container.go
@@ -70,6 +70,7 @@ func (u *UnikernelRuntime) CreateContainer(podSandboxID string, config *kubeapi.
 		Name:      cName,
 		SandboxID: podSandboxID,
 		Config:    config,
+		LogPath:   config.LogPath,
 	}
 
 	// TODO(Crazykev): Prepare container image

--- a/pkg/unikernel/service/sandbox.go
+++ b/pkg/unikernel/service/sandbox.go
@@ -67,6 +67,7 @@ func (u *UnikernelRuntime) RunPodSandbox(config *kubeapi.PodSandboxConfig) (stri
 		Name:     podName,
 		Config:   config,
 		VMConfig: vmMeta,
+		LogDir:   config.LogDirectory,
 	}
 
 	// TODO(Crazykev): Create ns and cni config

--- a/pkg/unikernel/service/sandbox.go
+++ b/pkg/unikernel/service/sandbox.go
@@ -118,14 +118,13 @@ func (u *UnikernelRuntime) RemovePodSandbox(podSandboxID string) error {
 		return fmt.Errorf("failed to get all containers for sandbox(%q): %v", podSandboxID, err)
 	}
 
-	// Remove related VM
-	if err = u.vmTool.RemoveVM(sandbox.ID); err != nil {
-		return fmt.Errorf("failed to remove sandbox(%q) vm: %v", sandbox.ID, err)
+	if len(ctrs) > 1 {
+		glog.Warningf("Get more than one(%d) containers in sandbox %q, remove them all", len(ctrs), sandbox.ID)
 	}
-	// Remove sandbox and containers metadata
+	// Remove all containers found in sandbox, althrough we expected only one exist.
 	for _, ctr := range ctrs {
-		if err = u.containerStore.Delete(ctr.ID); err != nil {
-			return fmt.Errorf("failed to delete container(%q) metadata: %v", ctr.ID, err)
+		if err = u.RemoveContainer(ctr.ID); err != nil {
+			return err
 		}
 	}
 	if err = u.sandboxStore.Delete(sandbox.ID); err != nil {
@@ -164,7 +163,6 @@ func (u *UnikernelRuntime) ListPodSandbox(filter *kubeapi.PodSandboxFilter) ([]*
 
 func makeSandboxName(podID string, meta *kubeapi.PodSandboxMetadata) string {
 	return strings.Join([]string{
-		podID[:11],
 		meta.Name,
 		meta.Namespace,
 		meta.Uid,

--- a/pkg/unikernel/service/unikernelruntime.go
+++ b/pkg/unikernel/service/unikernelruntime.go
@@ -60,13 +60,15 @@ type UnikernelRuntime struct {
 	defaultMem int32
 	// vmTool is the tools set to manipulate VM related operation.
 	vmTool *libvirt.VMTool
+	// enableLog determines whether vm's output print to file or console
+	enableLog bool
 }
 
 func (u *UnikernelRuntime) ServiceName() string {
 	return alternativeruntime.UnikernelRuntimeName
 }
 
-func NewUnikernelRuntimeService(cniNetDir, cniPluginDir, fraktiRoot string, defaultCPU, defaultMem int32) (*UnikernelRuntime, error) {
+func NewUnikernelRuntimeService(cniNetDir, cniPluginDir, fraktiRoot string, defaultCPU, defaultMem int32, enableLog bool) (*UnikernelRuntime, error) {
 	glog.Infof("Initialize unikernel runtime\n")
 
 	// Init VMTools
@@ -92,7 +94,8 @@ func NewUnikernelRuntimeService(cniNetDir, cniPluginDir, fraktiRoot string, defa
 		containerIDIndex:   truncindex.NewTruncIndex(nil),
 		defaultCPU:         defaultCPU,
 		defaultMem:         defaultMem,
-		vmTool:             libvirt.NewVMTool(conn),
+		vmTool:             libvirt.NewVMTool(conn, enableLog),
+		enableLog:          enableLog,
 	}
 
 	// Init root dir and image dir


### PR DESCRIPTION
1. enable basic unikernel log, we still need vm wrapper to reformat log from qemu.
2. enable vm ACPI, if not, it will hang at start time.
3. fix domain copy in ListDomains
4. enable basic libvirt bridge network for debug purpose.

/cc @feiskyer @resouer PTAL