### PR TITLE
Fix link after design proposal move

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Further information could be found at:
 
 - [Deploying](docs/deploy.md)
 - [End-to-end testing](docs/e2e-tests.md)
-- [Kubelet container runtime API](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/runtime-client-server.md)
+- [Kubelet container runtime API](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/runtime-client-server.md)
 - [HyperContainer](http://hypercontainer.io/)
 - [The blog on k8s.io about Hypernetes](http://blog.kubernetes.io/2016/05/hypernetes-security-and-multi-tenancy-in-kubernetes.html)
 


### PR DESCRIPTION
The design proposals were organized according to SIGs in kubernetes/community#1010. This led to a broken link in the README.