### PR TITLE
GetImageInfo: use Filter to get image instead of a full list

### DIFF
--- a/pkg/hyper/client.go
+++ b/pkg/hyper/client.go
@@ -278,8 +278,9 @@ func (c *Client) GetImageInfo(image, tag string) (*types.ImageInfo, error) {
 		repoSep = "@"
 	}
 
-	// TODO: use filter to get the image.
-	req := types.ImageListRequest{}
+	req := types.ImageListRequest{
+		Filter: strings.Join([]string{image, tag}, repoSep),
+	}
 	imageList, err := c.client.ImageList(ctx, &req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
the current GetImageInfo list all images and filter them in frakti.

The `Filter` parameter in the request could be used for filter it
in the hyperd side, which could avoid transferring the full image 
list and dropping them then.