### PR TITLE
Share flexvolume option file json format

### DIFF
--- a/pkg/flexvolume/cinder/flexvolume.go
+++ b/pkg/flexvolume/cinder/flexvolume.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	"k8s.io/frakti/pkg/util/knownflags"
+	"k8s.io/frakti/pkg/flexvolume"
 	utilmetadata "k8s.io/frakti/pkg/util/metadata"
 )
 
@@ -64,19 +64,19 @@ func (d *FlexVolumeDriver) initFlexVolumeDriverForMount(jsonOptions string) erro
 	var volOptions map[string]interface{}
 	json.Unmarshal([]byte(jsonOptions), &volOptions)
 
-	if len(volOptions[knownflags.VolIdKey].(string)) == 0 {
+	if len(volOptions[flexvolume.VolIdKey].(string)) == 0 {
 		return fmt.Errorf("jsonOptions is not set by user properly: %#v", jsonOptions)
 	}
 
 	// cinder configure file is optional in jsonOptions
-	if userConfig, ok := volOptions[knownflags.CinderConfigKey]; ok {
+	if userConfig, ok := volOptions[flexvolume.CinderConfigKey]; ok {
 		d.cinderConfig = userConfig.(string)
 	} else {
 		// use default configure if not provided
-		d.cinderConfig = knownflags.CinderConfigFile
+		d.cinderConfig = flexvolume.CinderConfigFile
 	}
 
-	d.volId = volOptions[knownflags.VolIdKey].(string)
+	d.volId = volOptions[flexvolume.VolIdKey].(string)
 	// this is a system option
 	d.fsType = volOptions["kubernetes.io/fsType"].(string)
 
@@ -97,9 +97,9 @@ func (d *FlexVolumeDriver) initFlexVolumeDriverForUnMount(targetMountDir string)
 		return err
 	}
 
-	d.cinderConfig = optsData[knownflags.CinderConfigKey].(string)
+	d.cinderConfig = optsData[flexvolume.CinderConfigKey].(string)
 
-	d.volId = optsData[knownflags.VolIdKey].(string)
+	d.volId = optsData[flexvolume.VolIdKey].(string)
 
 	manager, err := NewFlexManager(d.cinderConfig)
 	if err != nil {
@@ -169,10 +169,10 @@ func (d *FlexVolumeDriver) generateOptionsData(metadata map[string]interface{}) 
 	}
 
 	// these are used for detach
-	optsData[knownflags.VolIdKey] = d.volId
-	optsData[knownflags.CinderConfigKey] = d.cinderConfig
+	optsData[flexvolume.VolIdKey] = d.volId
+	optsData[flexvolume.CinderConfigKey] = d.cinderConfig
 
-	optsData[knownflags.FsTypeKey] = d.fsType
+	optsData[flexvolume.FsTypeKey] = d.fsType
 
 	return optsData
 }

--- a/pkg/flexvolume/cinder/flexvolume.go
+++ b/pkg/flexvolume/cinder/flexvolume.go
@@ -92,14 +92,15 @@ func (d *FlexVolumeDriver) initFlexVolumeDriverForMount(jsonOptions string) erro
 // initFlexVolumeDriverForUnMount use targetMountDir to initialize FlexVolumeDriver from magic file
 func (d *FlexVolumeDriver) initFlexVolumeDriverForUnMount(targetMountDir string) error {
 	// use the magic file to store volId since flexvolume will execute fresh new binary every time
-	optsData, err := utilmetadata.ReadJsonOptsFile(targetMountDir)
+	var optsData flexvolume.FlexVolumeOptsData
+	err := flexvolume.ReadJsonOptsFile(targetMountDir, &optsData)
 	if err != nil {
 		return err
 	}
 
-	d.cinderConfig = optsData[flexvolume.CinderConfigKey].(string)
+	d.cinderConfig = optsData.CinderData.ConfigKey
 
-	d.volId = optsData[flexvolume.VolIdKey].(string)
+	d.volId = optsData.CinderData.VolumeID
 
 	manager, err := NewFlexManager(d.cinderConfig)
 	if err != nil {
@@ -150,10 +151,11 @@ func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string
 	glog.V(3).Infof("Cinder volume %s attached", d.volId)
 
 	// append VolumeOptions with metadata
-	optsData := d.generateOptionsData(d.metadata)
-
+	optsData := &flexvolume.FlexVolumeOptsData{
+		CinderData: d.generateOptionsData(d.metadata),
+	}
 	// create a file and write metadata into the it
-	if err := utilmetadata.WriteJsonOptsFile(targetMountDir, optsData); err != nil {
+	if err := flexvolume.WriteJsonOptsFile(targetMountDir, optsData); err != nil {
 		os.Remove(targetMountDir)
 		detachDiskLogError(d)
 		return nil, err
@@ -162,19 +164,37 @@ func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string
 	return nil, nil
 }
 
-func (d *FlexVolumeDriver) generateOptionsData(metadata map[string]interface{}) map[string]interface{} {
-	optsData := map[string]interface{}{}
-	for k, v := range metadata {
-		optsData[k] = v
+func (d *FlexVolumeDriver) generateOptionsData(metadata map[string]interface{}) *flexvolume.CinderVolumeOptsData {
+	var result *flexvolume.CinderVolumeOptsData
+
+	result.ConfigKey = d.cinderConfig
+	result.VolumeID = d.volId
+	result.FsType = d.fsType
+
+	if data, ok := metadata["volume_type"]; ok {
+		result.VolumeType = data.(string)
+	}
+	if data, ok := metadata["name"]; ok {
+		result.Name = data.(string)
 	}
 
-	// these are used for detach
-	optsData[flexvolume.VolIdKey] = d.volId
-	optsData[flexvolume.CinderConfigKey] = d.cinderConfig
+	if data, ok := metadata["hosts"]; ok {
+		if hosts, err := utilmetadata.ExtractStringSlice(data); err != nil {
+			glog.V(4).Infof("cannot parse metadata hosts: %v", err)
+		} else {
+			result.Hosts = hosts
+		}
+	}
 
-	optsData[flexvolume.FsTypeKey] = d.fsType
+	if data, ok := metadata["ports"]; ok {
+		if ports, err := utilmetadata.ExtractStringSlice(data); err != nil {
+			glog.V(4).Infof("cannot parse metadata ports: %v", err)
+		} else {
+			result.Ports = ports
+		}
+	}
 
-	return optsData
+	return result
 }
 
 // detachDiskLogError is a wrapper to detach first before log error
@@ -205,7 +225,7 @@ func (d *FlexVolumeDriver) unmount(targetMountDir string) (map[string]interface{
 
 	// NOTE: the targetDir will be cleaned by flexvolume,
 	// we just need to clean up the metadata file.
-	if err := utilmetadata.CleanUpMetadataFile(targetMountDir); err != nil {
+	if err := flexvolume.CleanUpMetadataFile(targetMountDir); err != nil {
 		return nil, err
 	}
 

--- a/pkg/flexvolume/gcepd/flexvolume.go
+++ b/pkg/flexvolume/gcepd/flexvolume.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	"k8s.io/frakti/pkg/util/knownflags"
+	"k8s.io/frakti/pkg/flexvolume"
 	utilmetadata "k8s.io/frakti/pkg/util/metadata"
 )
 
@@ -64,14 +64,14 @@ func (d *FlexVolumeDriver) initFlexVolumeDriverForMount(jsonOptions string) erro
 	json.Unmarshal([]byte(jsonOptions), &volOptions)
 
 	// TODO(harry): check "volId zone project" are not nil to avoid panic, below check is useless.
-	if len(volOptions[knownflags.VolIdKey].(string)) == 0 {
+	if len(volOptions[flexvolume.VolIdKey].(string)) == 0 {
 		return fmt.Errorf("jsonOptions is not set by user properly: %#v", jsonOptions)
 	}
 
-	d.volId = volOptions[knownflags.VolIdKey].(string)
-	d.fsType = volOptions[knownflags.SystemFsTypeKey].(string)
-	d.zone = volOptions[knownflags.ZoneKey].(string)
-	d.project = volOptions[knownflags.ProjectKey].(string)
+	d.volId = volOptions[flexvolume.VolIdKey].(string)
+	d.fsType = volOptions[flexvolume.SystemFsTypeKey].(string)
+	d.zone = volOptions[flexvolume.ZoneKey].(string)
+	d.project = volOptions[flexvolume.ProjectKey].(string)
 
 	return nil
 }
@@ -84,9 +84,9 @@ func (d *FlexVolumeDriver) initFlexVolumeDriverForUnMount(targetMountDir string)
 		return err
 	}
 
-	d.volId = optsData[knownflags.VolIdKey].(string)
-	d.zone = optsData[knownflags.ZoneKey].(string)
-	d.project = optsData[knownflags.ProjectKey].(string)
+	d.volId = optsData[flexvolume.VolIdKey].(string)
+	d.zone = optsData[flexvolume.ZoneKey].(string)
+	d.project = optsData[flexvolume.ProjectKey].(string)
 
 	return nil
 }
@@ -146,12 +146,12 @@ func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string
 func (d *FlexVolumeDriver) generateOptionsData() map[string]interface{} {
 	optsData := map[string]interface{}{}
 
-	optsData[knownflags.VolIdKey] = d.volId
-	optsData[knownflags.FsTypeKey] = d.fsType
-	optsData[knownflags.ZoneKey] = d.zone
-	optsData[knownflags.ProjectKey] = d.project
+	optsData[flexvolume.VolIdKey] = d.volId
+	optsData[flexvolume.FsTypeKey] = d.fsType
+	optsData[flexvolume.ZoneKey] = d.zone
+	optsData[flexvolume.ProjectKey] = d.project
 
-	optsData[knownflags.DivcePathKey] = getDevPathByVolID(d.volId)
+	optsData[flexvolume.DivcePathKey] = getDevPathByVolID(d.volId)
 
 	return optsData
 }

--- a/pkg/flexvolume/gcepd/flexvolume.go
+++ b/pkg/flexvolume/gcepd/flexvolume.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/frakti/pkg/flexvolume"
-	utilmetadata "k8s.io/frakti/pkg/util/metadata"
 )
 
 type FlexVolumeDriver struct {
@@ -79,14 +78,15 @@ func (d *FlexVolumeDriver) initFlexVolumeDriverForMount(jsonOptions string) erro
 // initFlexVolumeDriverForUnMount use targetMountDir to initialize FlexVolumeDriver from tag file.
 func (d *FlexVolumeDriver) initFlexVolumeDriverForUnMount(targetMountDir string) error {
 	// Use the tag file to store volId since flexvolume will execute fresh new binary every time.
-	optsData, err := utilmetadata.ReadJsonOptsFile(targetMountDir)
+	var optsData flexvolume.FlexVolumeOptsData
+	err := flexvolume.ReadJsonOptsFile(targetMountDir, &optsData)
 	if err != nil {
 		return err
 	}
 
-	d.volId = optsData[flexvolume.VolIdKey].(string)
-	d.zone = optsData[flexvolume.ZoneKey].(string)
-	d.project = optsData[flexvolume.ProjectKey].(string)
+	d.volId = optsData.GCEPDData.VolumeID
+	d.zone = optsData.GCEPDData.Zone
+	d.project = optsData.GCEPDData.Project
 
 	return nil
 }
@@ -130,8 +130,10 @@ func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string
 	}
 
 	// Step 3: Create a json file and write metadata into the it.
-	optsData := d.generateOptionsData()
-	if err := utilmetadata.WriteJsonOptsFile(targetMountDir, optsData); err != nil {
+	optsData := &flexvolume.FlexVolumeOptsData{
+		GCEPDData: d.generateOptionsData(),
+	}
+	if err := flexvolume.WriteJsonOptsFile(targetMountDir, optsData); err != nil {
 		os.Remove(targetMountDir)
 		detachDiskLogError(d)
 		return nil, err
@@ -143,17 +145,14 @@ func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string
 }
 
 // generateOptionsData generates metadata for given GCE PD volume.
-func (d *FlexVolumeDriver) generateOptionsData() map[string]interface{} {
-	optsData := map[string]interface{}{}
-
-	optsData[flexvolume.VolIdKey] = d.volId
-	optsData[flexvolume.FsTypeKey] = d.fsType
-	optsData[flexvolume.ZoneKey] = d.zone
-	optsData[flexvolume.ProjectKey] = d.project
-
-	optsData[flexvolume.DivcePathKey] = getDevPathByVolID(d.volId)
-
-	return optsData
+func (d *FlexVolumeDriver) generateOptionsData() *flexvolume.GCEPDOptsData {
+	return &flexvolume.GCEPDOptsData{
+		VolumeID:   d.volId,
+		Zone:       d.zone,
+		Project:    d.project,
+		DevicePath: getDevPathByVolID(d.volId),
+		FsType:     d.fsType,
+	}
 }
 
 // detachDiskLogError is a wrapper to detach first before log error
@@ -182,7 +181,7 @@ func (d *FlexVolumeDriver) unmount(targetMountDir string) (map[string]interface{
 
 	// NOTE: the targetDir will be cleaned by flexvolume,
 	// we just need to clean up the metadata file.
-	if err := utilmetadata.CleanUpMetadataFile(targetMountDir); err != nil {
+	if err := flexvolume.CleanUpMetadataFile(targetMountDir); err != nil {
 		return nil, err
 	}
 

--- a/pkg/flexvolume/metadata.go
+++ b/pkg/flexvolume/metadata.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package knownflags
+package flexvolume
 
 const (
 	VolIdKey  = "volumeID"
@@ -34,3 +34,27 @@ const (
 	// Build-in fsType key of flexvolume
 	SystemFsTypeKey = "kubernetes.io/fsType"
 )
+
+// CinderVolumeOptsData is the struct of json file
+type CinderVolumeOptsData struct {
+	AccessMode   string   `json:"access_mode"`
+	AuthUserName string   `json:"auth_username"`
+	AuthEnabled  bool     `json:"auth_enabled"`
+	ClusterName  string   `json:"cluster_name"`
+	Encrypted    bool     `json:"encrypted"`
+	FsType       string   `json:"fsType"`
+	Hosts        []string `json:"hosts"`
+	Keyring      string   `json:"keyring"`
+	Name         string   `json:"name"`
+	Ports        []string `json:"ports"`
+	SecretUUID   string   `json:"secret_uuid"`
+	SecretType   string   `json:"secret_type"`
+	VolumeID     string   `json:"volumeID"`
+	VolumeType   string   `json:"volume_type"`
+}
+
+// GCEPDOptsData is the struct of json file
+type GCEPDOptsData struct {
+	DevicePath   string `json:"devicePath"`
+	SystemFsType string `json:"kubernetes.io/fsType"`
+}

--- a/pkg/flexvolume/metadata.go
+++ b/pkg/flexvolume/metadata.go
@@ -37,24 +37,26 @@ const (
 
 // CinderVolumeOptsData is the struct of json file
 type CinderVolumeOptsData struct {
-	AccessMode   string   `json:"access_mode"`
-	AuthUserName string   `json:"auth_username"`
-	AuthEnabled  bool     `json:"auth_enabled"`
-	ClusterName  string   `json:"cluster_name"`
-	Encrypted    bool     `json:"encrypted"`
-	FsType       string   `json:"fsType"`
-	Hosts        []string `json:"hosts"`
-	Keyring      string   `json:"keyring"`
-	Name         string   `json:"name"`
-	Ports        []string `json:"ports"`
-	SecretUUID   string   `json:"secret_uuid"`
-	SecretType   string   `json:"secret_type"`
-	VolumeID     string   `json:"volumeID"`
-	VolumeType   string   `json:"volume_type"`
+	// Needed to reconstruct new cinder clients
+	ConfigKey string `json:"cinderConfig"`
+	VolumeID  string `json:"volumeID"`
+
+	// rbd volume details
+	VolumeType string   `json:"volume_type"`
+	Name       string   `json:"name"`
+	FsType     string   `json:"fsType"`
+	Hosts      []string `json:"hosts"`
+	Ports      []string `json:"ports"`
 }
 
 // GCEPDOptsData is the struct of json file
 type GCEPDOptsData struct {
+	// Needed for unmount
+	VolumeID string `json:"volumeID"`
+	Zone     string `json:"zone"`
+	Project  string `json:"project"`
+
+	// gce pd volume details
 	DevicePath   string `json:"devicePath"`
 	SystemFsType string `json:"kubernetes.io/fsType"`
 }

--- a/pkg/flexvolume/metadata.go
+++ b/pkg/flexvolume/metadata.go
@@ -16,6 +16,14 @@ limitations under the License.
 
 package flexvolume
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	utilmetadata "k8s.io/frakti/pkg/util/metadata"
+)
+
 const (
 	VolIdKey  = "volumeID"
 	FsTypeKey = "fsType"
@@ -57,6 +65,27 @@ type GCEPDOptsData struct {
 	Project  string `json:"project"`
 
 	// gce pd volume details
-	DevicePath   string `json:"devicePath"`
-	SystemFsType string `json:"kubernetes.io/fsType"`
+	DevicePath string `json:"devicePath"`
+	FsType     string `json:"fsType"`
+}
+
+type FlexVolumeOptsData struct {
+	CinderData *CinderVolumeOptsData `json:"cinderVolumeOptsData,omitempty"`
+	GCEPDData  *GCEPDOptsData        `json:"gCEPDOptsData,omitempty"`
+}
+
+func WriteJsonOptsFile(targetDir string, opts interface{}) error {
+	return utilmetadata.WriteJson(filepath.Join(targetDir, HyperFlexvolumeDataFile), opts, 0700)
+}
+
+func ReadJsonOptsFile(targetDir string, opts interface{}) error {
+	return utilmetadata.ReadJson(filepath.Join(targetDir, HyperFlexvolumeDataFile), opts)
+}
+
+func CleanUpMetadataFile(targetDir string) error {
+	metadataFile := filepath.Join(targetDir, HyperFlexvolumeDataFile)
+	if err := os.Remove(metadataFile); err != nil {
+		return fmt.Errorf("removing metadata file: %v failed: %v", metadataFile, err)
+	}
+	return nil
 }

--- a/pkg/flexvolume/metadata_test.go
+++ b/pkg/flexvolume/metadata_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flexvolume
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var defaultCinderVolume = &CinderVolumeOptsData{
+	ConfigKey:  "emptyKey",
+	VolumeID:   "fooVolume",
+	VolumeType: "rbd",
+	Name:       "volumeNameBar",
+	FsType:     "fstype_empty",
+	Hosts:      []string{"host1", "host2"},
+	Ports:      []string{"port1", "port2"},
+}
+
+var defaultGcePdVolume = &GCEPDOptsData{
+	VolumeID:   "volumebar",
+	Zone:       "earch",
+	Project:    "frakti",
+	DevicePath: "Aroad",
+	FsType:     "empty",
+}
+
+const testDir = "/tmp"
+
+func TestSaveLoadCinderOptsData(t *testing.T) {
+	src := defaultCinderVolume
+
+	err := WriteJsonOptsFile(testDir, src)
+	assert.Nil(t, err, "write cinder json")
+
+	var dst CinderVolumeOptsData
+	err = ReadJsonOptsFile(testDir, &dst)
+	assert.Nil(t, err, "read cinder json")
+
+	assert.True(t, reflect.DeepEqual(*src, dst))
+}
+
+func TestSaveLoadGCEPDOptsData(t *testing.T) {
+	src := defaultGcePdVolume
+
+	err := WriteJsonOptsFile(testDir, src)
+	assert.Nil(t, err, "write gcepd json")
+
+	var dst GCEPDOptsData
+	err = ReadJsonOptsFile(testDir, &dst)
+	assert.Nil(t, err, "read gcepd json")
+
+	assert.True(t, reflect.DeepEqual(*src, dst))
+}
+
+func TestSaveLoadFlexVolumeOptsData(t *testing.T) {
+	src := &FlexVolumeOptsData{
+		CinderData: defaultCinderVolume,
+		GCEPDData:  defaultGcePdVolume,
+	}
+
+	err := WriteJsonOptsFile(testDir, src)
+	assert.Nil(t, err, "write flex volume json")
+
+	var dst FlexVolumeOptsData
+	err = ReadJsonOptsFile(testDir, &dst)
+	assert.Nil(t, err, "read flex volume json")
+
+	assert.True(t, reflect.DeepEqual(*src, dst))
+}

--- a/pkg/hyper/container.go
+++ b/pkg/hyper/container.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/frakti/pkg/flexvolume"
 	"k8s.io/frakti/pkg/hyper/types"
-	utilmetadata "k8s.io/frakti/pkg/util/metadata"
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
@@ -102,16 +101,8 @@ func buildUserContainer(config *kubeapi.ContainerConfig, sandboxConfig *kubeapi.
 	return containerSpec, nil
 }
 
-func getVolumeForCinder(volumeOptsFile, volName string, m *kubeapi.Mount) (*types.UserVolumeReference, error) {
+func makeVolumeForCinder(optsData *flexvolume.CinderVolumeOptsData, volName string, m *kubeapi.Mount) (*types.UserVolumeReference, error) {
 	// this is a cinder-flexvolume
-	optsData := flexvolume.CinderVolumeOptsData{}
-	if err := utilmetadata.ReadJson(volumeOptsFile, &optsData); err != nil {
-		return nil, fmt.Errorf(
-			"buildUserContainer() failed: can't read Cinder flexvolume data file: %q: %v",
-			volumeOptsFile, err,
-		)
-	}
-
 	if optsData.VolumeType == "rbd" {
 		monitors := make([]string, 0, 1)
 		for _, host := range optsData.Hosts {
@@ -138,20 +129,13 @@ func getVolumeForCinder(volumeOptsFile, volName string, m *kubeapi.Mount) (*type
 	return nil, fmt.Errorf("got wrong volume type: %v, expected: rbd", optsData.VolumeType)
 }
 
-func getVolumeForGCEPD(volumeOptsFile, volName string, m *kubeapi.Mount) (*types.UserVolumeReference, error) {
+func makeVolumeForGCEPD(optsData *flexvolume.GCEPDOptsData, volName string, m *kubeapi.Mount) (*types.UserVolumeReference, error) {
 	// this is a gcepd-flexvolume
-	optsData := flexvolume.GCEPDOptsData{}
-	if err := utilmetadata.ReadJson(volumeOptsFile, &optsData); err != nil {
-		return nil, fmt.Errorf(
-			"buildUserContainer() failed: can't read GCE PD flexvolume data file: %q: %v",
-			volumeOptsFile, err,
-		)
-	}
 	volDetail := &types.UserVolume{
 		Name:   volName + fmt.Sprintf("_%08x", rand.Uint32()),
 		Source: optsData.DevicePath,
 		Format: "raw",
-		Fstype: optsData.SystemFsType,
+		Fstype: optsData.FsType,
 	}
 	return &types.UserVolumeReference{
 		// use the generated volume name above
@@ -163,12 +147,12 @@ func getVolumeForGCEPD(volumeOptsFile, volName string, m *kubeapi.Mount) (*types
 }
 
 func isHyperFlexVolume(hostPath, volumeOptsFile string) bool {
-	// no-exist hostPath is allowed, and that case should never be cinder flexvolume
+	// no-exist hostPath is allowed, and that case should never be hyper flexvolume
 	if hostPathInfo, err := os.Stat(hostPath); !os.IsNotExist(err) {
 		// 1. host path is a directory (filter out bind mounted files like /etc/hosts)
 		if hostPathInfo.IsDir() {
 			// 2. tag file exists in host path
-			if _, err := os.Stat(volumeOptsFile); !os.IsNotExist(err) {
+			if _, err := os.Stat(filepath.Join(hostPath, volumeOptsFile)); !os.IsNotExist(err) {
 				// 3. then this is a HyperFlexvolume
 				return true
 			}
@@ -186,20 +170,25 @@ func makeContainerVolumes(config *kubeapi.ContainerConfig) ([]*types.UserVolumeR
 		_, volName := filepath.Split(hostPath)
 
 		// In frakti, we can both use normal container volumes (-v host:path), and also hyper-flexvolume
-		volumeOptsFile := filepath.Join(hostPath, flexvolume.HyperFlexvolumeDataFile)
+		if isHyperFlexVolume(hostPath, flexvolume.HyperFlexvolumeDataFile) {
+			var err error
 
-		if isHyperFlexVolume(hostPath, volumeOptsFile) {
-			var (
-				err error
-			)
+			optsData := flexvolume.FlexVolumeOptsData{}
+			if err := flexvolume.ReadJsonOptsFile(hostPath, &optsData); err != nil {
+				return nil, fmt.Errorf(
+					"buildUserContainer() failed: can't read Cinder flexvolume data file in %q: %v",
+					hostPath, err,
+				)
+			}
+
 			switch {
-			case strings.Contains(hostPath, "cinder~rbd"):
-				if volumes[i], err = getVolumeForCinder(volumeOptsFile, volName, m); err != nil {
+			case optsData.CinderData != nil:
+				if volumes[i], err = makeVolumeForCinder(optsData.CinderData, volName, m); err != nil {
 					return nil, err
 				}
 
-			case strings.Contains(hostPath, "gce~pd"):
-				if volumes[i], err = getVolumeForGCEPD(volumeOptsFile, volName, m); err != nil {
+			case optsData.GCEPDData != nil:
+				if volumes[i], err = makeVolumeForGCEPD(optsData.GCEPDData, volName, m); err != nil {
 					return nil, err
 				}
 			default:

--- a/pkg/util/metadata/metadata.go
+++ b/pkg/util/metadata/metadata.go
@@ -22,10 +22,21 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
-
-	"k8s.io/frakti/pkg/flexvolume"
 )
+
+func ExtractStringSlice(s interface{}) ([]string, error) {
+	bs, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	err = json.Unmarshal(bs, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
 // MapToJson converts the specified map object to indented JSON.
 // It panics in case if the map connot be converted.
@@ -67,27 +78,6 @@ func WriteJson(filename string, v interface{}, perm os.FileMode) error {
 	}
 	if err := ioutil.WriteFile(filename, content, perm); err != nil {
 		return fmt.Errorf("error writing JSON data file %q: %v", filename, err)
-	}
-	return nil
-}
-
-func WriteJsonOptsFile(targetDir string, opts map[string]interface{}) error {
-	return WriteJson(filepath.Join(targetDir, flexvolume.HyperFlexvolumeDataFile), opts, 0700)
-}
-
-func ReadJsonOptsFile(targetDir string) (map[string]interface{}, error) {
-	var result map[string]interface{}
-	err := ReadJson(filepath.Join(targetDir, flexvolume.HyperFlexvolumeDataFile), &result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func CleanUpMetadataFile(targetDir string) error {
-	metadataFile := filepath.Join(targetDir, flexvolume.HyperFlexvolumeDataFile)
-	if err := os.Remove(metadataFile); err != nil {
-		return fmt.Errorf("removing metadata file: %v failed: %v", metadataFile, err)
 	}
 	return nil
 }

--- a/pkg/util/metadata/metadata.go
+++ b/pkg/util/metadata/metadata.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/frakti/pkg/util/knownflags"
+	"k8s.io/frakti/pkg/flexvolume"
 )
 
 // MapToJson converts the specified map object to indented JSON.
@@ -72,12 +72,12 @@ func WriteJson(filename string, v interface{}, perm os.FileMode) error {
 }
 
 func WriteJsonOptsFile(targetDir string, opts map[string]interface{}) error {
-	return WriteJson(filepath.Join(targetDir, knownflags.HyperFlexvolumeDataFile), opts, 0700)
+	return WriteJson(filepath.Join(targetDir, flexvolume.HyperFlexvolumeDataFile), opts, 0700)
 }
 
 func ReadJsonOptsFile(targetDir string) (map[string]interface{}, error) {
 	var result map[string]interface{}
-	err := ReadJson(filepath.Join(targetDir, knownflags.HyperFlexvolumeDataFile), &result)
+	err := ReadJson(filepath.Join(targetDir, flexvolume.HyperFlexvolumeDataFile), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func ReadJsonOptsFile(targetDir string) (map[string]interface{}, error) {
 }
 
 func CleanUpMetadataFile(targetDir string) error {
-	metadataFile := filepath.Join(targetDir, knownflags.HyperFlexvolumeDataFile)
+	metadataFile := filepath.Join(targetDir, flexvolume.HyperFlexvolumeDataFile)
 	if err := os.Remove(metadataFile); err != nil {
 		return fmt.Errorf("removing metadata file: %v failed: %v", metadataFile, err)
 	}


### PR DESCRIPTION
Share volume options json format between cinder and gcepd
flex volumes so that we use the json file contents rather
than hostpath to identify different flex volume types.