### PR TITLE
hyper: filter images with image name

### DIFF
--- a/pkg/hyper/client.go
+++ b/pkg/hyper/client.go
@@ -279,7 +279,7 @@ func (c *Client) GetImageInfo(image, tag string) (*types.ImageInfo, error) {
 	}
 
 	req := types.ImageListRequest{
-		Filter: strings.Join([]string{image, tag}, repoSep),
+		Filter: image,
 	}
 	imageList, err := c.client.ImageList(ctx, &req)
 	if err != nil {


### PR DESCRIPTION
The hyper ImageList API does not support filter format
<name@tag>. Just filter with image name.

Fixes #286 