### PR TITLE
Dockershim

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/BUILD
@@ -101,8 +101,6 @@ go_test(
         "//conditions:default": [],
     }),
     data = [
-        "fixtures/seccomp/sub/subtest",
-        "fixtures/seccomp/test",
     ],
     importpath = "k8s.io/kubernetes/pkg/kubelet/dockershim",
     library = ":go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/convert_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/convert_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"testing"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+)
+
+func TestConvertDockerStatusToRuntimeAPIState(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected runtimeapi.ContainerState
+	}{
+		{input: "Up 5 hours", expected: runtimeapi.ContainerState_CONTAINER_RUNNING},
+		{input: "Exited (0) 2 hours ago", expected: runtimeapi.ContainerState_CONTAINER_EXITED},
+		{input: "Created", expected: runtimeapi.ContainerState_CONTAINER_CREATED},
+		{input: "Random string", expected: runtimeapi.ContainerState_CONTAINER_UNKNOWN},
+	}
+
+	for _, test := range testCases {
+		actual := toRuntimeAPIContainerState(test.input)
+		assert.Equal(t, test.expected, actual)
+	}
+}
+
+func TestConvertToPullableImageID(t *testing.T) {
+	testCases := []struct {
+		id       string
+		image    *dockertypes.ImageInspect
+		expected string
+	}{
+		{
+			id: "image-1",
+			image: &dockertypes.ImageInspect{
+				RepoDigests: []string{"digest-1"},
+			},
+			expected: DockerPullableImageIDPrefix + "digest-1",
+		},
+		{
+			id: "image-2",
+			image: &dockertypes.ImageInspect{
+				RepoDigests: []string{},
+			},
+			expected: DockerImageIDPrefix + "image-2",
+		},
+	}
+
+	for _, test := range testCases {
+		actual := toPullableImageID(test.id, test.image)
+		assert.Equal(t, test.expected, actual)
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_checkpoint_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_checkpoint_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	utilstore "k8s.io/kubernetes/pkg/kubelet/dockershim/testing"
+)
+
+func NewTestPersistentCheckpointHandler() CheckpointHandler {
+	return &PersistentCheckpointHandler{store: utilstore.NewMemStore()}
+}
+
+func TestPersistentCheckpointHandler(t *testing.T) {
+	var err error
+	handler := NewTestPersistentCheckpointHandler()
+	port80 := int32(80)
+	port443 := int32(443)
+	proto := protocolTCP
+
+	checkpoint1 := NewPodSandboxCheckpoint("ns1", "sandbox1")
+	checkpoint1.Data.PortMappings = []*PortMapping{
+		{
+			&proto,
+			&port80,
+			&port80,
+		},
+		{
+			&proto,
+			&port443,
+			&port443,
+		},
+	}
+	checkpoint1.Data.HostNetwork = true
+
+	checkpoints := []struct {
+		podSandboxID      string
+		checkpoint        *PodSandboxCheckpoint
+		expectHostNetwork bool
+	}{
+		{
+			"id1",
+			checkpoint1,
+			true,
+		},
+		{
+			"id2",
+			NewPodSandboxCheckpoint("ns2", "sandbox2"),
+			false,
+		},
+	}
+
+	for _, tc := range checkpoints {
+		// Test CreateCheckpoints
+		err = handler.CreateCheckpoint(tc.podSandboxID, tc.checkpoint)
+		assert.NoError(t, err)
+
+		// Test GetCheckpoints
+		checkpoint, err := handler.GetCheckpoint(tc.podSandboxID)
+		assert.NoError(t, err)
+		assert.Equal(t, *checkpoint, *tc.checkpoint)
+		assert.Equal(t, checkpoint.Data.HostNetwork, tc.expectHostNetwork)
+	}
+	// Test ListCheckpoints
+	keys, err := handler.ListCheckpoints()
+	assert.NoError(t, err)
+	sort.Strings(keys)
+	assert.Equal(t, keys, []string{"id1", "id2"})
+
+	// Test RemoveCheckpoints
+	err = handler.RemoveCheckpoint("id1")
+	assert.NoError(t, err)
+	// Test Remove Nonexisted Checkpoints
+	err = handler.RemoveCheckpoint("id1")
+	assert.NoError(t, err)
+
+	// Test ListCheckpoints
+	keys, err = handler.ListCheckpoints()
+	assert.NoError(t, err)
+	assert.Equal(t, keys, []string{"id2"})
+
+	// Test Get NonExisted Checkpoint
+	_, err = handler.GetCheckpoint("id1")
+	assert.Error(t, err)
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_container_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_container_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
+)
+
+// A helper to create a basic config.
+func makeContainerConfig(sConfig *runtimeapi.PodSandboxConfig, name, image string, attempt uint32, labels, annotations map[string]string) *runtimeapi.ContainerConfig {
+	return &runtimeapi.ContainerConfig{
+		Metadata: &runtimeapi.ContainerMetadata{
+			Name:    name,
+			Attempt: attempt,
+		},
+		Image:       &runtimeapi.ImageSpec{Image: image},
+		Labels:      labels,
+		Annotations: annotations,
+	}
+}
+
+// TestListContainers creates several containers and then list them to check
+// whether the correct metadatas, states, and labels are returned.
+func TestListContainers(t *testing.T) {
+	ds, _, fakeClock := newTestDockerService()
+	podName, namespace := "foo", "bar"
+	containerName, image := "sidecar", "logger"
+
+	configs := []*runtimeapi.ContainerConfig{}
+	sConfigs := []*runtimeapi.PodSandboxConfig{}
+	for i := 0; i < 3; i++ {
+		s := makeSandboxConfig(fmt.Sprintf("%s%d", podName, i),
+			fmt.Sprintf("%s%d", namespace, i), fmt.Sprintf("%d", i), 0)
+		labels := map[string]string{"abc.xyz": fmt.Sprintf("label%d", i)}
+		annotations := map[string]string{"foo.bar.baz": fmt.Sprintf("annotation%d", i)}
+		c := makeContainerConfig(s, fmt.Sprintf("%s%d", containerName, i),
+			fmt.Sprintf("%s:v%d", image, i), uint32(i), labels, annotations)
+		sConfigs = append(sConfigs, s)
+		configs = append(configs, c)
+	}
+
+	expected := []*runtimeapi.Container{}
+	state := runtimeapi.ContainerState_CONTAINER_RUNNING
+	var createdAt int64 = fakeClock.Now().UnixNano()
+	for i := range configs {
+		// We don't care about the sandbox id; pass a bogus one.
+		sandboxID := fmt.Sprintf("sandboxid%d", i)
+		id, err := ds.CreateContainer(sandboxID, configs[i], sConfigs[i])
+		assert.NoError(t, err)
+		err = ds.StartContainer(id)
+		assert.NoError(t, err)
+
+		imageRef := "" // FakeDockerClient doesn't populate ImageRef yet.
+		// Prepend to the expected list because ListContainers returns
+		// the most recent containers first.
+		expected = append([]*runtimeapi.Container{{
+			Metadata:     configs[i].Metadata,
+			Id:           id,
+			PodSandboxId: sandboxID,
+			State:        state,
+			CreatedAt:    createdAt,
+			Image:        configs[i].Image,
+			ImageRef:     imageRef,
+			Labels:       configs[i].Labels,
+			Annotations:  configs[i].Annotations,
+		}}, expected...)
+	}
+	containers, err := ds.ListContainers(nil)
+	assert.NoError(t, err)
+	assert.Len(t, containers, len(expected))
+	assert.Equal(t, expected, containers)
+}
+
+// TestContainerStatus tests the basic lifecycle operations and verify that
+// the status returned reflects the operations performed.
+func TestContainerStatus(t *testing.T) {
+	ds, fDocker, fClock := newTestDockerService()
+	sConfig := makeSandboxConfig("foo", "bar", "1", 0)
+	labels := map[string]string{"abc.xyz": "foo"}
+	annotations := map[string]string{"foo.bar.baz": "abc"}
+	imageName := "iamimage"
+	config := makeContainerConfig(sConfig, "pause", imageName, 0, labels, annotations)
+
+	var defaultTime time.Time
+	dt := defaultTime.UnixNano()
+	ct, st, ft := dt, dt, dt
+	state := runtimeapi.ContainerState_CONTAINER_CREATED
+	imageRef := DockerImageIDPrefix + imageName
+	// The following variables are not set in FakeDockerClient.
+	exitCode := int32(0)
+	var reason, message string
+
+	expected := &runtimeapi.ContainerStatus{
+		State:       state,
+		CreatedAt:   ct,
+		StartedAt:   st,
+		FinishedAt:  ft,
+		Metadata:    config.Metadata,
+		Image:       config.Image,
+		ImageRef:    imageRef,
+		ExitCode:    exitCode,
+		Reason:      reason,
+		Message:     message,
+		Mounts:      []*runtimeapi.Mount{},
+		Labels:      config.Labels,
+		Annotations: config.Annotations,
+	}
+
+	fDocker.InjectImages([]dockertypes.ImageSummary{{ID: imageName}})
+
+	// Create the container.
+	fClock.SetTime(time.Now().Add(-1 * time.Hour))
+	expected.CreatedAt = fClock.Now().UnixNano()
+	const sandboxId = "sandboxid"
+	id, err := ds.CreateContainer(sandboxId, config, sConfig)
+	assert.NoError(t, err)
+
+	// Check internal labels
+	c, err := fDocker.InspectContainer(id)
+	assert.NoError(t, err)
+	assert.Equal(t, c.Config.Labels[containerTypeLabelKey], containerTypeLabelContainer)
+	assert.Equal(t, c.Config.Labels[sandboxIDLabelKey], sandboxId)
+
+	// Set the id manually since we don't know the id until it's created.
+	expected.Id = id
+	assert.NoError(t, err)
+	status, err := ds.ContainerStatus(id)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, status)
+
+	// Advance the clock and start the container.
+	fClock.SetTime(time.Now())
+	expected.StartedAt = fClock.Now().UnixNano()
+	expected.State = runtimeapi.ContainerState_CONTAINER_RUNNING
+
+	err = ds.StartContainer(id)
+	assert.NoError(t, err)
+	status, err = ds.ContainerStatus(id)
+	assert.Equal(t, expected, status)
+
+	// Advance the clock and stop the container.
+	fClock.SetTime(time.Now().Add(1 * time.Hour))
+	expected.FinishedAt = fClock.Now().UnixNano()
+	expected.State = runtimeapi.ContainerState_CONTAINER_EXITED
+	expected.Reason = "Completed"
+
+	err = ds.StopContainer(id, 0)
+	assert.NoError(t, err)
+	status, err = ds.ContainerStatus(id)
+	assert.Equal(t, expected, status)
+
+	// Remove the container.
+	err = ds.RemoveContainer(id)
+	assert.NoError(t, err)
+	status, err = ds.ContainerStatus(id)
+	assert.Error(t, err, fmt.Sprintf("status of container: %+v", status))
+}
+
+// TestContainerLogPath tests the container log creation logic.
+func TestContainerLogPath(t *testing.T) {
+	ds, fDocker, _ := newTestDockerService()
+	podLogPath := "/pod/1"
+	containerLogPath := "0"
+	kubeletContainerLogPath := filepath.Join(podLogPath, containerLogPath)
+	sConfig := makeSandboxConfig("foo", "bar", "1", 0)
+	sConfig.LogDirectory = podLogPath
+	config := makeContainerConfig(sConfig, "pause", "iamimage", 0, nil, nil)
+	config.LogPath = containerLogPath
+
+	const sandboxId = "sandboxid"
+	id, err := ds.CreateContainer(sandboxId, config, sConfig)
+
+	// Check internal container log label
+	c, err := fDocker.InspectContainer(id)
+	assert.NoError(t, err)
+	assert.Equal(t, c.Config.Labels[containerLogPathLabelKey], kubeletContainerLogPath)
+
+	// Set docker container log path
+	dockerContainerLogPath := "/docker/container/log"
+	c.LogPath = dockerContainerLogPath
+
+	// Verify container log symlink creation
+	fakeOS := ds.os.(*containertest.FakeOS)
+	fakeOS.SymlinkFn = func(oldname, newname string) error {
+		assert.Equal(t, dockerContainerLogPath, oldname)
+		assert.Equal(t, kubeletContainerLogPath, newname)
+		return nil
+	}
+	err = ds.StartContainer(id)
+	assert.NoError(t, err)
+
+	err = ds.StopContainer(id, 0)
+	assert.NoError(t, err)
+
+	// Verify container log symlink deletion
+	// symlink is also tentatively deleted at startup
+	err = ds.RemoveContainer(id)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{kubeletContainerLogPath, kubeletContainerLogPath}, fakeOS.Removes)
+}
+
+// TestContainerCreationConflict tests the logic to work around docker container
+// creation naming conflict bug.
+func TestContainerCreationConflict(t *testing.T) {
+	sConfig := makeSandboxConfig("foo", "bar", "1", 0)
+	config := makeContainerConfig(sConfig, "pause", "iamimage", 0, map[string]string{}, map[string]string{})
+	containerName := makeContainerName(sConfig, config)
+	const sandboxId = "sandboxid"
+	const containerId = "containerid"
+	conflictError := fmt.Errorf("Error response from daemon: Conflict. The name \"/%s\" is already in use by container %s. You have to remove (or rename) that container to be able to reuse that name.",
+		containerName, containerId)
+	noContainerError := fmt.Errorf("Error response from daemon: No such container: %s", containerId)
+	randomError := fmt.Errorf("random error")
+
+	for desc, test := range map[string]struct {
+		createError  error
+		removeError  error
+		expectError  error
+		expectCalls  []string
+		expectFields int
+	}{
+		"no create error": {
+			expectCalls:  []string{"create"},
+			expectFields: 6,
+		},
+		"random create error": {
+			createError: randomError,
+			expectError: randomError,
+			expectCalls: []string{"create"},
+		},
+		"conflict create error with successful remove": {
+			createError: conflictError,
+			expectError: conflictError,
+			expectCalls: []string{"create", "remove"},
+		},
+		"conflict create error with random remove error": {
+			createError: conflictError,
+			removeError: randomError,
+			expectError: conflictError,
+			expectCalls: []string{"create", "remove"},
+		},
+		"conflict create error with no such container remove error": {
+			createError:  conflictError,
+			removeError:  noContainerError,
+			expectCalls:  []string{"create", "remove", "create"},
+			expectFields: 7,
+		},
+	} {
+		t.Logf("TestCase: %s", desc)
+		ds, fDocker, _ := newTestDockerService()
+
+		if test.createError != nil {
+			fDocker.InjectError("create", test.createError)
+		}
+		if test.removeError != nil {
+			fDocker.InjectError("remove", test.removeError)
+		}
+		id, err := ds.CreateContainer(sandboxId, config, sConfig)
+		require.Equal(t, test.expectError, err)
+		assert.NoError(t, fDocker.AssertCalls(test.expectCalls))
+		if err == nil {
+			c, err := fDocker.InspectContainer(id)
+			assert.NoError(t, err)
+			assert.Len(t, strings.Split(c.Name, nameDelimiter), test.expectFields)
+		}
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_image_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_image_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"fmt"
+	"testing"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/stretchr/testify/assert"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+)
+
+func TestRemoveImage(t *testing.T) {
+	ds, fakeDocker, _ := newTestDockerService()
+	id := "1111"
+	fakeDocker.InjectImageInspects([]dockertypes.ImageInspect{{ID: id, RepoTags: []string{"foo"}}})
+	ds.RemoveImage(&runtimeapi.ImageSpec{Image: id})
+	fakeDocker.AssertCallDetails(libdocker.NewCalledDetail("inspect_image", nil),
+		libdocker.NewCalledDetail("remove_image", []interface{}{id, dockertypes.ImageRemoveOptions{PruneChildren: true}}))
+}
+
+func TestRemoveImageWithMultipleTags(t *testing.T) {
+	ds, fakeDocker, _ := newTestDockerService()
+	id := "1111"
+	fakeDocker.InjectImageInspects([]dockertypes.ImageInspect{{ID: id, RepoTags: []string{"foo", "bar"}}})
+	ds.RemoveImage(&runtimeapi.ImageSpec{Image: id})
+	fakeDocker.AssertCallDetails(libdocker.NewCalledDetail("inspect_image", nil),
+		libdocker.NewCalledDetail("remove_image", []interface{}{"foo", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
+		libdocker.NewCalledDetail("remove_image", []interface{}{"bar", dockertypes.ImageRemoveOptions{PruneChildren: true}}))
+}
+
+func TestPullWithJSONError(t *testing.T) {
+	ds, fakeDocker, _ := newTestDockerService()
+	tests := map[string]struct {
+		image         *runtimeapi.ImageSpec
+		err           error
+		expectedError string
+	}{
+		"Json error": {
+			&runtimeapi.ImageSpec{Image: "ubuntu"},
+			&jsonmessage.JSONError{Code: 50, Message: "Json error"},
+			"Json error",
+		},
+		"Bad gateway": {
+			&runtimeapi.ImageSpec{Image: "ubuntu"},
+			&jsonmessage.JSONError{Code: 502, Message: "<!doctype html>\n<html class=\"no-js\" lang=\"\">\n    <head>\n  </head>\n    <body>\n   <h1>Oops, there was an error!</h1>\n        <p>We have been contacted of this error, feel free to check out <a href=\"http://status.docker.com/\">status.docker.com</a>\n           to see if there is a bigger issue.</p>\n\n    </body>\n</html>"},
+			"RegistryUnavailable",
+		},
+	}
+	for key, test := range tests {
+		fakeDocker.InjectError("pull", test.err)
+		_, err := ds.PullImage(test.image, &runtimeapi.AuthConfig{})
+		assert.Error(t, err, fmt.Sprintf("TestCase [%s]", key))
+		assert.Contains(t, err.Error(), test.expectedError)
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+	"k8s.io/kubernetes/pkg/kubelet/network"
+	"k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+// A helper to create a basic config.
+func makeSandboxConfig(name, namespace, uid string, attempt uint32) *runtimeapi.PodSandboxConfig {
+	return makeSandboxConfigWithLabelsAndAnnotations(name, namespace, uid, attempt, map[string]string{}, map[string]string{})
+}
+
+func makeSandboxConfigWithLabelsAndAnnotations(name, namespace, uid string, attempt uint32, labels, annotations map[string]string) *runtimeapi.PodSandboxConfig {
+	return &runtimeapi.PodSandboxConfig{
+		Metadata: &runtimeapi.PodSandboxMetadata{
+			Name:      name,
+			Namespace: namespace,
+			Uid:       uid,
+			Attempt:   attempt,
+		},
+		Labels:      labels,
+		Annotations: annotations,
+	}
+}
+
+// TestListSandboxes creates several sandboxes and then list them to check
+// whether the correct metadatas, states, and labels are returned.
+func TestListSandboxes(t *testing.T) {
+	ds, _, fakeClock := newTestDockerService()
+	name, namespace := "foo", "bar"
+	configs := []*runtimeapi.PodSandboxConfig{}
+	for i := 0; i < 3; i++ {
+		c := makeSandboxConfigWithLabelsAndAnnotations(fmt.Sprintf("%s%d", name, i),
+			fmt.Sprintf("%s%d", namespace, i), fmt.Sprintf("%d", i), 0,
+			map[string]string{"label": fmt.Sprintf("foo%d", i)},
+			map[string]string{"annotation": fmt.Sprintf("bar%d", i)},
+		)
+		configs = append(configs, c)
+	}
+
+	expected := []*runtimeapi.PodSandbox{}
+	state := runtimeapi.PodSandboxState_SANDBOX_READY
+	var createdAt int64 = fakeClock.Now().UnixNano()
+	for i := range configs {
+		id, err := ds.RunPodSandbox(configs[i])
+		assert.NoError(t, err)
+		// Prepend to the expected list because ListPodSandbox returns
+		// the most recent sandbox first.
+		expected = append([]*runtimeapi.PodSandbox{{
+			Metadata:    configs[i].Metadata,
+			Id:          id,
+			State:       state,
+			CreatedAt:   createdAt,
+			Labels:      configs[i].Labels,
+			Annotations: configs[i].Annotations,
+		}}, expected...)
+	}
+	sandboxes, err := ds.ListPodSandbox(nil)
+	assert.NoError(t, err)
+	assert.Len(t, sandboxes, len(expected))
+	assert.Equal(t, expected, sandboxes)
+}
+
+// TestSandboxStatus tests the basic lifecycle operations and verify that
+// the status returned reflects the operations performed.
+func TestSandboxStatus(t *testing.T) {
+	ds, fDocker, fClock := newTestDockerService()
+	labels := map[string]string{"label": "foobar1"}
+	annotations := map[string]string{"annotation": "abc"}
+	config := makeSandboxConfigWithLabelsAndAnnotations("foo", "bar", "1", 0, labels, annotations)
+
+	// TODO: The following variables depend on the internal
+	// implementation of FakeDockerClient, and should be fixed.
+	fakeIP := "2.3.4.5"
+
+	state := runtimeapi.PodSandboxState_SANDBOX_READY
+	ct := int64(0)
+	hostNetwork := false
+	expected := &runtimeapi.PodSandboxStatus{
+		State:       state,
+		CreatedAt:   ct,
+		Metadata:    config.Metadata,
+		Network:     &runtimeapi.PodSandboxNetworkStatus{Ip: fakeIP},
+		Linux:       &runtimeapi.LinuxPodSandboxStatus{Namespaces: &runtimeapi.Namespace{Options: &runtimeapi.NamespaceOption{HostNetwork: hostNetwork}}},
+		Labels:      labels,
+		Annotations: annotations,
+	}
+
+	// Create the sandbox.
+	fClock.SetTime(time.Now())
+	expected.CreatedAt = fClock.Now().UnixNano()
+	id, err := ds.RunPodSandbox(config)
+
+	// Check internal labels
+	c, err := fDocker.InspectContainer(id)
+	assert.NoError(t, err)
+	assert.Equal(t, c.Config.Labels[containerTypeLabelKey], containerTypeLabelSandbox)
+	assert.Equal(t, c.Config.Labels[types.KubernetesContainerNameLabel], sandboxContainerName)
+
+	expected.Id = id // ID is only known after the creation.
+	status, err := ds.PodSandboxStatus(id)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, status)
+
+	// Stop the sandbox.
+	expected.State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+	err = ds.StopPodSandbox(id)
+	assert.NoError(t, err)
+	// IP not valid after sandbox stop
+	expected.Network.Ip = ""
+	status, err = ds.PodSandboxStatus(id)
+	assert.Equal(t, expected, status)
+
+	// Remove the container.
+	err = ds.RemovePodSandbox(id)
+	assert.NoError(t, err)
+	status, err = ds.PodSandboxStatus(id)
+	assert.Error(t, err, fmt.Sprintf("status of sandbox: %+v", status))
+}
+
+// TestSandboxStatusAfterRestart tests that retrieving sandbox status returns
+// an IP address even if RunPodSandbox() was not yet called for this pod, as
+// would happen on kubelet restart
+func TestSandboxStatusAfterRestart(t *testing.T) {
+	ds, _, fClock := newTestDockerService()
+	config := makeSandboxConfig("foo", "bar", "1", 0)
+
+	// TODO: The following variables depend on the internal
+	// implementation of FakeDockerClient, and should be fixed.
+	fakeIP := "2.3.4.5"
+
+	state := runtimeapi.PodSandboxState_SANDBOX_READY
+	ct := int64(0)
+	hostNetwork := false
+	expected := &runtimeapi.PodSandboxStatus{
+		State:       state,
+		CreatedAt:   ct,
+		Metadata:    config.Metadata,
+		Network:     &runtimeapi.PodSandboxNetworkStatus{Ip: fakeIP},
+		Linux:       &runtimeapi.LinuxPodSandboxStatus{Namespaces: &runtimeapi.Namespace{Options: &runtimeapi.NamespaceOption{HostNetwork: hostNetwork}}},
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}
+
+	// Create the sandbox.
+	fClock.SetTime(time.Now())
+	expected.CreatedAt = fClock.Now().UnixNano()
+
+	createConfig, err := ds.makeSandboxDockerConfig(config, defaultSandboxImage)
+	assert.NoError(t, err)
+
+	createResp, err := ds.client.CreateContainer(*createConfig)
+	assert.NoError(t, err)
+	err = ds.client.StartContainer(createResp.ID)
+	assert.NoError(t, err)
+
+	// Check status without RunPodSandbox() having set up networking
+	expected.Id = createResp.ID // ID is only known after the creation.
+	status, err := ds.PodSandboxStatus(createResp.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, status)
+}
+
+// TestNetworkPluginInvocation checks that the right SetUpPod and TearDownPod
+// calls are made when we run/stop a sandbox.
+func TestNetworkPluginInvocation(t *testing.T) {
+	ds, _, _ := newTestDockerService()
+	mockPlugin := newTestNetworkPlugin(t)
+	ds.network = network.NewPluginManager(mockPlugin)
+	defer mockPlugin.Finish()
+
+	name := "foo0"
+	ns := "bar0"
+	c := makeSandboxConfigWithLabelsAndAnnotations(
+		name, ns, "0", 0,
+		map[string]string{"label": name},
+		map[string]string{"annotation": ns},
+	)
+	cID := kubecontainer.ContainerID{Type: runtimeName, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
+
+	mockPlugin.EXPECT().Name().Return("mockNetworkPlugin").AnyTimes()
+	setup := mockPlugin.EXPECT().SetUpPod(ns, name, cID)
+	// StopPodSandbox performs a lookup on status to figure out if the sandbox
+	// is running with hostnetworking, as all its given is the ID.
+	mockPlugin.EXPECT().GetPodNetworkStatus(ns, name, cID)
+	mockPlugin.EXPECT().TearDownPod(ns, name, cID).After(setup)
+
+	_, err := ds.RunPodSandbox(c)
+	assert.NoError(t, err)
+	err = ds.StopPodSandbox(cID.ID)
+	assert.NoError(t, err)
+}
+
+// TestHostNetworkPluginInvocation checks that *no* SetUp/TearDown calls happen
+// for host network sandboxes.
+func TestHostNetworkPluginInvocation(t *testing.T) {
+	ds, _, _ := newTestDockerService()
+	mockPlugin := newTestNetworkPlugin(t)
+	ds.network = network.NewPluginManager(mockPlugin)
+	defer mockPlugin.Finish()
+
+	name := "foo0"
+	ns := "bar0"
+	c := makeSandboxConfigWithLabelsAndAnnotations(
+		name, ns, "0", 0,
+		map[string]string{"label": name},
+		map[string]string{"annotation": ns},
+	)
+	hostNetwork := true
+	c.Linux = &runtimeapi.LinuxPodSandboxConfig{
+		SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
+			NamespaceOptions: &runtimeapi.NamespaceOption{
+				HostNetwork: hostNetwork,
+			},
+		},
+	}
+	cID := kubecontainer.ContainerID{Type: runtimeName, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
+
+	// No calls to network plugin are expected
+	_, err := ds.RunPodSandbox(c)
+	assert.NoError(t, err)
+	assert.NoError(t, ds.StopPodSandbox(cID.ID))
+}
+
+// TestSetUpPodFailure checks that the sandbox should be not ready when it
+// hits a SetUpPod failure.
+func TestSetUpPodFailure(t *testing.T) {
+	ds, _, _ := newTestDockerService()
+	mockPlugin := newTestNetworkPlugin(t)
+	ds.network = network.NewPluginManager(mockPlugin)
+	defer mockPlugin.Finish()
+
+	name := "foo0"
+	ns := "bar0"
+	c := makeSandboxConfigWithLabelsAndAnnotations(
+		name, ns, "0", 0,
+		map[string]string{"label": name},
+		map[string]string{"annotation": ns},
+	)
+	cID := kubecontainer.ContainerID{Type: runtimeName, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
+	mockPlugin.EXPECT().Name().Return("mockNetworkPlugin").AnyTimes()
+	mockPlugin.EXPECT().SetUpPod(ns, name, cID).Return(errors.New("setup pod error")).AnyTimes()
+	// Assume network plugin doesn't return error, dockershim should still be able to return not ready correctly.
+	mockPlugin.EXPECT().GetPodNetworkStatus(ns, name, cID).Return(&network.PodNetworkStatus{IP: net.IP("127.0.0.01")}, nil).AnyTimes()
+
+	t.Logf("RunPodSandbox should return error")
+	_, err := ds.RunPodSandbox(c)
+	assert.Error(t, err)
+
+	t.Logf("PodSandboxStatus should be not ready")
+	status, err := ds.PodSandboxStatus(cID.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, runtimeapi.PodSandboxState_SANDBOX_NOTREADY, status.State)
+
+	t.Logf("ListPodSandbox should also show not ready")
+	sandboxes, err := ds.ListPodSandbox(nil)
+	assert.NoError(t, err)
+	var sandbox *runtimeapi.PodSandbox
+	for _, s := range sandboxes {
+		if s.Id == cID.ID {
+			sandbox = s
+			break
+		}
+	}
+	assert.NotNil(t, sandbox)
+	assert.Equal(t, runtimeapi.PodSandboxState_SANDBOX_NOTREADY, sandbox.State)
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_service.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_service.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network/kubenet"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
 	"k8s.io/kubernetes/pkg/kubelet/util/cache"
+	utilstore "k8s.io/kubernetes/pkg/kubelet/util/store"
 
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/metrics"
@@ -365,6 +366,9 @@ func (ds *dockerService) GetPodPortMappings(podSandboxID string) ([]*hostport.Po
 	checkpoint, err := ds.checkpointHandler.GetCheckpoint(podSandboxID)
 	// Return empty portMappings if checkpoint is not found
 	if err != nil {
+		if err == utilstore.ErrKeyNotFound {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_service_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_service_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blang/semver"
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+	"k8s.io/kubernetes/pkg/kubelet/network"
+	nettest "k8s.io/kubernetes/pkg/kubelet/network/testing"
+	"k8s.io/kubernetes/pkg/kubelet/util/cache"
+)
+
+// newTestNetworkPlugin returns a mock plugin that implements network.NetworkPlugin
+func newTestNetworkPlugin(t *testing.T) *nettest.MockNetworkPlugin {
+	ctrl := gomock.NewController(t)
+	return nettest.NewMockNetworkPlugin(ctrl)
+}
+
+func newTestDockerService() (*dockerService, *libdocker.FakeDockerClient, *clock.FakeClock) {
+	fakeClock := clock.NewFakeClock(time.Time{})
+	c := libdocker.NewFakeDockerClient().WithClock(fakeClock).WithVersion("1.11.2", "1.23")
+	pm := network.NewPluginManager(&network.NoopNetworkPlugin{})
+	return &dockerService{
+		client:            c,
+		os:                &containertest.FakeOS{},
+		network:           pm,
+		checkpointHandler: NewTestPersistentCheckpointHandler(),
+		networkReady:      make(map[string]bool),
+	}, c, fakeClock
+}
+
+func newTestDockerServiceWithVersionCache() (*dockerService, *libdocker.FakeDockerClient, *clock.FakeClock) {
+	ds, c, fakeClock := newTestDockerService()
+	ds.versionCache = cache.NewObjectCache(
+		func() (interface{}, error) {
+			return ds.getDockerVersion()
+		},
+		time.Hour*10,
+	)
+	return ds, c, fakeClock
+}
+
+// TestStatus tests the runtime status logic.
+func TestStatus(t *testing.T) {
+	ds, fDocker, _ := newTestDockerService()
+
+	assertStatus := func(expected map[string]bool, status *runtimeapi.RuntimeStatus) {
+		conditions := status.GetConditions()
+		assert.Equal(t, len(expected), len(conditions))
+		for k, v := range expected {
+			for _, c := range conditions {
+				if k == c.Type {
+					assert.Equal(t, v, c.Status)
+				}
+			}
+		}
+	}
+
+	// Should report ready status if version returns no error.
+	status, err := ds.Status()
+	assert.NoError(t, err)
+	assertStatus(map[string]bool{
+		runtimeapi.RuntimeReady: true,
+		runtimeapi.NetworkReady: true,
+	}, status)
+
+	// Should not report ready status if version returns error.
+	fDocker.InjectError("version", errors.New("test error"))
+	status, err = ds.Status()
+	assert.NoError(t, err)
+	assertStatus(map[string]bool{
+		runtimeapi.RuntimeReady: false,
+		runtimeapi.NetworkReady: true,
+	}, status)
+
+	// Should not report ready status is network plugin returns error.
+	mockPlugin := newTestNetworkPlugin(t)
+	ds.network = network.NewPluginManager(mockPlugin)
+	defer mockPlugin.Finish()
+	mockPlugin.EXPECT().Status().Return(errors.New("network error"))
+	status, err = ds.Status()
+	assert.NoError(t, err)
+	assertStatus(map[string]bool{
+		runtimeapi.RuntimeReady: true,
+		runtimeapi.NetworkReady: false,
+	}, status)
+}
+
+func TestVersion(t *testing.T) {
+	ds, _, _ := newTestDockerService()
+
+	expectedVersion := &dockertypes.Version{Version: "1.11.2", APIVersion: "1.23.0"}
+	v, err := ds.getDockerVersion()
+	require.NoError(t, err)
+	assert.Equal(t, expectedVersion, v)
+
+	expectedAPIVersion := &semver.Version{Major: 1, Minor: 23, Patch: 0}
+	apiVersion, err := ds.getDockerAPIVersion()
+	require.NoError(t, err)
+	assert.Equal(t, expectedAPIVersion, apiVersion)
+}
+
+func TestAPIVersionWithCache(t *testing.T) {
+	ds, _, _ := newTestDockerServiceWithVersionCache()
+
+	expected := &semver.Version{Major: 1, Minor: 23, Patch: 0}
+	version, err := ds.getDockerAPIVersion()
+	require.NoError(t, err)
+	assert.Equal(t, expected, version)
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers_linux.go
@@ -62,7 +62,11 @@ func getSeccompDockerOpts(seccompProfile string) ([]dockerOpt, error) {
 		return nil, fmt.Errorf("unknown seccomp profile option: %s", seccompProfile)
 	}
 
-	fname := strings.TrimPrefix(seccompProfile, "localhost/") // by pod annotation validation, name is a valid subpath
+	// get the full path of seccomp profile when prefixed with 'localhost/'.
+	fname := strings.TrimPrefix(seccompProfile, "localhost/")
+	if !filepath.IsAbs(fname) {
+		return nil, fmt.Errorf("seccomp profile path must be absolute, but got relative path %q", fname)
+	}
 	file, err := ioutil.ReadFile(filepath.FromSlash(fname))
 	if err != nil {
 		return nil, fmt.Errorf("cannot load seccomp profile %q: %v", fname, err)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers_linux_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers_linux_test.go
@@ -1,0 +1,103 @@
+// +build linux
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSeccompSecurityOpts(t *testing.T) {
+	tests := []struct {
+		msg            string
+		seccompProfile string
+		expectedOpts   []string
+	}{{
+		msg:            "No security annotations",
+		seccompProfile: "",
+		expectedOpts:   []string{"seccomp=unconfined"},
+	}, {
+		msg:            "Seccomp unconfined",
+		seccompProfile: "unconfined",
+		expectedOpts:   []string{"seccomp=unconfined"},
+	}, {
+		msg:            "Seccomp default",
+		seccompProfile: "docker/default",
+		expectedOpts:   nil,
+	}}
+
+	for i, test := range tests {
+		opts, err := getSeccompSecurityOpts(test.seccompProfile, '=')
+		assert.NoError(t, err, "TestCase[%d]: %s", i, test.msg)
+		assert.Len(t, opts, len(test.expectedOpts), "TestCase[%d]: %s", i, test.msg)
+		for _, opt := range test.expectedOpts {
+			assert.Contains(t, opts, opt, "TestCase[%d]: %s", i, test.msg)
+		}
+	}
+}
+
+func TestLoadSeccompLocalhostProfiles(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "seccomp-local-profile-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+	testProfile := `{"foo": "bar"}`
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "test"), []byte(testProfile), 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		msg            string
+		seccompProfile string
+		expectedOpts   []string
+		expectErr      bool
+	}{{
+		msg:            "Seccomp localhost/test profile should return correct seccomp profiles",
+		seccompProfile: "localhost/" + filepath.Join(tmpdir, "test"),
+		expectedOpts:   []string{`seccomp={"foo":"bar"}`},
+		expectErr:      false,
+	}, {
+		msg:            "Non-existent profile should return error",
+		seccompProfile: "localhost/" + filepath.Join(tmpdir, "fixtures/non-existent"),
+		expectedOpts:   nil,
+		expectErr:      true,
+	}, {
+		msg:            "Relative profile path should return error",
+		seccompProfile: "localhost/fixtures/test",
+		expectedOpts:   nil,
+		expectErr:      true,
+	}}
+
+	for i, test := range tests {
+		opts, err := getSeccompSecurityOpts(test.seccompProfile, '=')
+		if test.expectErr {
+			assert.Error(t, err, fmt.Sprintf("TestCase[%d]: %s", i, test.msg))
+			continue
+		}
+		assert.NoError(t, err, "TestCase[%d]: %s", i, test.msg)
+		assert.Len(t, opts, len(test.expectedOpts), "TestCase[%d]: %s", i, test.msg)
+		for _, opt := range test.expectedOpts {
+			assert.Contains(t, opts, opt, "TestCase[%d]: %s", i, test.msg)
+		}
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers_test.go
@@ -1,0 +1,371 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blang/semver"
+	dockertypes "github.com/docker/docker/api/types"
+	dockernat "github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+	"k8s.io/kubernetes/pkg/security/apparmor"
+)
+
+func TestLabelsAndAnnotationsRoundTrip(t *testing.T) {
+	expectedLabels := map[string]string{"foo.123.abc": "baz", "bar.456.xyz": "qwe"}
+	expectedAnnotations := map[string]string{"uio.ert": "dfs", "jkl": "asd"}
+	// Merge labels and annotations into docker labels.
+	dockerLabels := makeLabels(expectedLabels, expectedAnnotations)
+	// Extract labels and annotations from docker labels.
+	actualLabels, actualAnnotations := extractLabels(dockerLabels)
+	assert.Equal(t, expectedLabels, actualLabels)
+	assert.Equal(t, expectedAnnotations, actualAnnotations)
+}
+
+// TestGetApparmorSecurityOpts tests the logic of generating container apparmor options from sandbox annotations.
+func TestGetApparmorSecurityOpts(t *testing.T) {
+	makeConfig := func(profile string) *runtimeapi.LinuxContainerSecurityContext {
+		return &runtimeapi.LinuxContainerSecurityContext{
+			ApparmorProfile: profile,
+		}
+	}
+
+	tests := []struct {
+		msg          string
+		config       *runtimeapi.LinuxContainerSecurityContext
+		expectedOpts []string
+	}{{
+		msg:          "No AppArmor options",
+		config:       makeConfig(""),
+		expectedOpts: nil,
+	}, {
+		msg:          "AppArmor runtime/default",
+		config:       makeConfig("runtime/default"),
+		expectedOpts: []string{},
+	}, {
+		msg:          "AppArmor local profile",
+		config:       makeConfig(apparmor.ProfileNamePrefix + "foo"),
+		expectedOpts: []string{"apparmor=foo"},
+	}}
+
+	for i, test := range tests {
+		opts, err := getApparmorSecurityOpts(test.config, '=')
+		assert.NoError(t, err, "TestCase[%d]: %s", i, test.msg)
+		assert.Len(t, opts, len(test.expectedOpts), "TestCase[%d]: %s", i, test.msg)
+		for _, opt := range test.expectedOpts {
+			assert.Contains(t, opts, opt, "TestCase[%d]: %s", i, test.msg)
+		}
+	}
+}
+
+// TestGetUserFromImageUser tests the logic of getting image uid or user name of image user.
+func TestGetUserFromImageUser(t *testing.T) {
+	newI64 := func(i int64) *int64 { return &i }
+	for c, test := range map[string]struct {
+		user string
+		uid  *int64
+		name string
+	}{
+		"no gid": {
+			user: "0",
+			uid:  newI64(0),
+		},
+		"uid/gid": {
+			user: "0:1",
+			uid:  newI64(0),
+		},
+		"empty user": {
+			user: "",
+		},
+		"multiple spearators": {
+			user: "1:2:3",
+			uid:  newI64(1),
+		},
+		"root username": {
+			user: "root:root",
+			name: "root",
+		},
+		"username": {
+			user: "test:test",
+			name: "test",
+		},
+	} {
+		t.Logf("TestCase - %q", c)
+		actualUID, actualName := getUserFromImageUser(test.user)
+		assert.Equal(t, test.uid, actualUID)
+		assert.Equal(t, test.name, actualName)
+	}
+}
+
+func TestParsingCreationConflictError(t *testing.T) {
+	// Expected error message from docker.
+	msg := "Conflict. The name \"/k8s_POD_pfpod_e2e-tests-port-forwarding-dlxt2_81a3469e-99e1-11e6-89f2-42010af00002_0\" is already in use by container 24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e. You have to remove (or rename) that container to be able to reuse that name."
+
+	matches := conflictRE.FindStringSubmatch(msg)
+	require.Len(t, matches, 2)
+	require.Equal(t, matches[1], "24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e")
+}
+
+func TestGetSecurityOptSeparator(t *testing.T) {
+	for c, test := range map[string]struct {
+		desc     string
+		version  *semver.Version
+		expected rune
+	}{
+		"older docker version": {
+			version:  &semver.Version{Major: 1, Minor: 22, Patch: 0},
+			expected: ':',
+		},
+		"changed docker version": {
+			version:  &semver.Version{Major: 1, Minor: 23, Patch: 0},
+			expected: '=',
+		},
+		"newer docker version": {
+			version:  &semver.Version{Major: 1, Minor: 24, Patch: 0},
+			expected: '=',
+		},
+	} {
+		actual := getSecurityOptSeparator(test.version)
+		assert.Equal(t, test.expected, actual, c)
+	}
+}
+
+// writeDockerConfig will write a config file into a temporary dir, and return that dir.
+// Caller is responsible for deleting the dir and its contents.
+func writeDockerConfig(cfg string) (string, error) {
+	tmpdir, err := ioutil.TempDir("", "dockershim=helpers_test.go=")
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(tmpdir, ".docker")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		return "", err
+	}
+	return tmpdir, ioutil.WriteFile(filepath.Join(dir, "config.json"), []byte(cfg), 0644)
+}
+
+func TestEnsureSandboxImageExists(t *testing.T) {
+	sandboxImage := "gcr.io/test/image"
+	authConfig := dockertypes.AuthConfig{Username: "user", Password: "pass"}
+	for desc, test := range map[string]struct {
+		injectImage  bool
+		imgNeedsAuth bool
+		injectErr    error
+		calls        []string
+		err          bool
+		configJSON   string
+	}{
+		"should not pull image when it already exists": {
+			injectImage: true,
+			injectErr:   nil,
+			calls:       []string{"inspect_image"},
+		},
+		"should pull image when it doesn't exist": {
+			injectImage: false,
+			injectErr:   libdocker.ImageNotFoundError{ID: "image_id"},
+			calls:       []string{"inspect_image", "pull"},
+		},
+		"should return error when inspect image fails": {
+			injectImage: false,
+			injectErr:   fmt.Errorf("arbitrary error"),
+			calls:       []string{"inspect_image"},
+			err:         true,
+		},
+		"should return error when image pull needs private auth, but none provided": {
+			injectImage:  true,
+			imgNeedsAuth: true,
+			injectErr:    libdocker.ImageNotFoundError{ID: "image_id"},
+			calls:        []string{"inspect_image", "pull"},
+			err:          true,
+		},
+	} {
+		t.Logf("TestCase: %q", desc)
+		_, fakeDocker, _ := newTestDockerService()
+		if test.injectImage {
+			images := []dockertypes.ImageSummary{{ID: sandboxImage}}
+			fakeDocker.InjectImages(images)
+			if test.imgNeedsAuth {
+				fakeDocker.MakeImagesPrivate(images, authConfig)
+			}
+		}
+		fakeDocker.InjectError("inspect_image", test.injectErr)
+
+		err := ensureSandboxImageExists(fakeDocker, sandboxImage)
+		assert.NoError(t, fakeDocker.AssertCalls(test.calls))
+		assert.Equal(t, test.err, err != nil)
+	}
+}
+
+func TestMakePortsAndBindings(t *testing.T) {
+	for desc, test := range map[string]struct {
+		pm           []*runtimeapi.PortMapping
+		exposedPorts dockernat.PortSet
+		portmappings map[dockernat.Port][]dockernat.PortBinding
+	}{
+		"no port mapping": {
+			pm:           nil,
+			exposedPorts: map[dockernat.Port]struct{}{},
+			portmappings: map[dockernat.Port][]dockernat.PortBinding{},
+		},
+		"tcp port mapping": {
+			pm: []*runtimeapi.PortMapping{
+				{
+					Protocol:      runtimeapi.Protocol_TCP,
+					ContainerPort: 80,
+					HostPort:      80,
+				},
+			},
+			exposedPorts: map[dockernat.Port]struct{}{
+				"80/tcp": {},
+			},
+			portmappings: map[dockernat.Port][]dockernat.PortBinding{
+				"80/tcp": {
+					{
+						HostPort: "80",
+					},
+				},
+			},
+		},
+		"udp port mapping": {
+			pm: []*runtimeapi.PortMapping{
+				{
+					Protocol:      runtimeapi.Protocol_UDP,
+					ContainerPort: 80,
+					HostPort:      80,
+				},
+			},
+			exposedPorts: map[dockernat.Port]struct{}{
+				"80/udp": {},
+			},
+			portmappings: map[dockernat.Port][]dockernat.PortBinding{
+				"80/udp": {
+					{
+						HostPort: "80",
+					},
+				},
+			},
+		},
+		"multipe port mappings": {
+			pm: []*runtimeapi.PortMapping{
+				{
+					Protocol:      runtimeapi.Protocol_TCP,
+					ContainerPort: 80,
+					HostPort:      80,
+				},
+				{
+					Protocol:      runtimeapi.Protocol_TCP,
+					ContainerPort: 80,
+					HostPort:      81,
+				},
+			},
+			exposedPorts: map[dockernat.Port]struct{}{
+				"80/tcp": {},
+			},
+			portmappings: map[dockernat.Port][]dockernat.PortBinding{
+				"80/tcp": {
+					{
+						HostPort: "80",
+					},
+					{
+						HostPort: "81",
+					},
+				},
+			},
+		},
+	} {
+		t.Logf("TestCase: %s", desc)
+		actualExposedPorts, actualPortMappings := makePortsAndBindings(test.pm)
+		assert.Equal(t, test.exposedPorts, actualExposedPorts)
+		assert.Equal(t, test.portmappings, actualPortMappings)
+	}
+}
+
+func TestGenerateMountBindings(t *testing.T) {
+	mounts := []*runtimeapi.Mount{
+		// everything default
+		{
+			HostPath:      "/mnt/1",
+			ContainerPath: "/var/lib/mysql/1",
+		},
+		// readOnly
+		{
+			HostPath:      "/mnt/2",
+			ContainerPath: "/var/lib/mysql/2",
+			Readonly:      true,
+		},
+		// SELinux
+		{
+			HostPath:       "/mnt/3",
+			ContainerPath:  "/var/lib/mysql/3",
+			SelinuxRelabel: true,
+		},
+		// Propagation private
+		{
+			HostPath:      "/mnt/4",
+			ContainerPath: "/var/lib/mysql/4",
+			Propagation:   runtimeapi.MountPropagation_PROPAGATION_PRIVATE,
+		},
+		// Propagation rslave
+		{
+			HostPath:      "/mnt/5",
+			ContainerPath: "/var/lib/mysql/5",
+			Propagation:   runtimeapi.MountPropagation_PROPAGATION_HOST_TO_CONTAINER,
+		},
+		// Propagation rshared
+		{
+			HostPath:      "/mnt/6",
+			ContainerPath: "/var/lib/mysql/6",
+			Propagation:   runtimeapi.MountPropagation_PROPAGATION_BIDIRECTIONAL,
+		},
+		// Propagation unknown (falls back to private)
+		{
+			HostPath:      "/mnt/7",
+			ContainerPath: "/var/lib/mysql/7",
+			Propagation:   runtimeapi.MountPropagation(42),
+		},
+		// Everything
+		{
+			HostPath:       "/mnt/8",
+			ContainerPath:  "/var/lib/mysql/8",
+			Readonly:       true,
+			SelinuxRelabel: true,
+			Propagation:    runtimeapi.MountPropagation_PROPAGATION_BIDIRECTIONAL,
+		},
+	}
+	expectedResult := []string{
+		"/mnt/1:/var/lib/mysql/1",
+		"/mnt/2:/var/lib/mysql/2:ro",
+		"/mnt/3:/var/lib/mysql/3:Z",
+		"/mnt/4:/var/lib/mysql/4",
+		"/mnt/5:/var/lib/mysql/5:rslave",
+		"/mnt/6:/var/lib/mysql/6:rshared",
+		"/mnt/7:/var/lib/mysql/7",
+		"/mnt/8:/var/lib/mysql/8:ro,Z,rshared",
+	}
+	result := generateMountBindings(mounts)
+
+	assert.Equal(t, result, expectedResult)
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker/helpers_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libdocker
+
+import (
+	"fmt"
+	"testing"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchImageTagOrSHA(t *testing.T) {
+	for i, testCase := range []struct {
+		Inspected dockertypes.ImageInspect
+		Image     string
+		Output    bool
+	}{
+		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"ubuntu:latest"}},
+			Image:     "ubuntu",
+			Output:    true,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"ubuntu:14.04"}},
+			Image:     "ubuntu:latest",
+			Output:    false,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"colemickens/hyperkube-amd64:217.9beff63"}},
+			Image:     "colemickens/hyperkube-amd64:217.9beff63",
+			Output:    true,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"colemickens/hyperkube-amd64:217.9beff63"}},
+			Image:     "docker.io/colemickens/hyperkube-amd64:217.9beff63",
+			Output:    true,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"docker.io/kubernetes/pause:latest"}},
+			Image:     "kubernetes/pause:latest",
+			Output:    true,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			},
+			Image:  "myimage@sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			Output: true,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			},
+			Image:  "myimage@sha256:2208f7a29005",
+			Output: false,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			},
+			Image:  "myimage@sha256:2208",
+			Output: false,
+		},
+		{
+			// mismatched ID is ignored
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			},
+			Image:  "myimage@sha256:0000f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			Output: false,
+		},
+		{
+			// invalid digest is ignored
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:unparseable",
+			},
+			Image:  "myimage@sha256:unparseable",
+			Output: false,
+		},
+		{
+			// v1 schema images can be pulled in one format and returned in another
+			Inspected: dockertypes.ImageInspect{
+				ID:          "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoDigests: []string{"centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf"},
+			},
+			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+			Output: true,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID:       "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoTags: []string{"docker.io/busybox:latest"},
+			},
+			Image:  "docker.io/library/busybox:latest",
+			Output: true,
+		},
+		{
+			// RepoDigest match is is required
+			Inspected: dockertypes.ImageInspect{
+				ID:          "",
+				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:000084acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf"},
+			},
+			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+			Output: false,
+		},
+		{
+			// RepoDigest match is allowed
+			Inspected: dockertypes.ImageInspect{
+				ID:          "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf"},
+			},
+			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+			Output: true,
+		},
+		{
+			// RepoDigest and ID are checked
+			Inspected: dockertypes.ImageInspect{
+				ID:          "sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227"},
+			},
+			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+			Output: true,
+		},
+		{
+			// unparseable RepoDigests are skipped
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoDigests: []string{
+					"centos/ruby-23-centos7@sha256:unparseable",
+					"docker.io/centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+				},
+			},
+			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+			Output: true,
+		},
+		{
+			// unparseable RepoDigest is ignored
+			Inspected: dockertypes.ImageInspect{
+				ID:          "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:unparseable"},
+			},
+			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+			Output: false,
+		},
+		{
+			// unparseable image digest is ignored
+			Inspected: dockertypes.ImageInspect{
+				ID:          "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:unparseable"},
+			},
+			Image:  "centos/ruby-23-centos7@sha256:unparseable",
+			Output: false,
+		},
+		{
+			// prefix match is rejected for ID and RepoDigest
+			Inspected: dockertypes.ImageInspect{
+				ID:          "sha256:unparseable",
+				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:unparseable"},
+			},
+			Image:  "sha256:unparseable",
+			Output: false,
+		},
+		{
+			// possible SHA prefix match is rejected for ID and RepoDigest because it is not in the named format
+			Inspected: dockertypes.ImageInspect{
+				ID:          "sha256:0000f247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:0000f247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227"},
+			},
+			Image:  "sha256:0000",
+			Output: false,
+		},
+	} {
+		match := matchImageTagOrSHA(testCase.Inspected, testCase.Image)
+		assert.Equal(t, testCase.Output, match, testCase.Image+fmt.Sprintf(" is not a match (%d)", i))
+	}
+}
+
+func TestMatchImageIDOnly(t *testing.T) {
+	for i, testCase := range []struct {
+		Inspected dockertypes.ImageInspect
+		Image     string
+		Output    bool
+	}{
+		// shouldn't match names or tagged names
+		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"ubuntu:latest"}},
+			Image:     "ubuntu",
+			Output:    false,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{RepoTags: []string{"colemickens/hyperkube-amd64:217.9beff63"}},
+			Image:     "colemickens/hyperkube-amd64:217.9beff63",
+			Output:    false,
+		},
+		// should match name@digest refs if they refer to the image ID (but only the full ID)
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			},
+			Image:  "myimage@sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			Output: true,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			},
+			Image:  "myimage@sha256:2208f7a29005",
+			Output: false,
+		},
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			},
+			Image:  "myimage@sha256:2208",
+			Output: false,
+		},
+		// should match when the IDs are literally the same
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "foobar",
+			},
+			Image:  "foobar",
+			Output: true,
+		},
+		// shouldn't match mismatched IDs
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:2208f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			},
+			Image:  "myimage@sha256:0000f7a29005d226d1ee33a63e33af1f47af6156c740d7d23c7948e8d282d53d",
+			Output: false,
+		},
+		// shouldn't match invalid IDs or refs
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID: "sha256:unparseable",
+			},
+			Image:  "myimage@sha256:unparseable",
+			Output: false,
+		},
+		// shouldn't match against repo digests
+		{
+			Inspected: dockertypes.ImageInspect{
+				ID:          "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoDigests: []string{"centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf"},
+			},
+			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+			Output: false,
+		},
+	} {
+		match := matchImageIDOnly(testCase.Inspected, testCase.Image)
+		assert.Equal(t, testCase.Output, match, fmt.Sprintf("%s is not a match (%d)", testCase.Image, i))
+	}
+
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker/kube_docker_client_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker/kube_docker_client_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libdocker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsContainerNotFoundError(t *testing.T) {
+	// Expected error message from docker.
+	containerNotFoundError := fmt.Errorf("Error response from daemon: No such container: 96e914f31579e44fe49b239266385330a9b2125abeb9254badd9fca74580c95a")
+	otherError := fmt.Errorf("Error response from daemon: Other errors")
+
+	assert.True(t, IsContainerNotFoundError(containerNotFoundError))
+	assert.False(t, IsContainerNotFoundError(otherError))
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/naming_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/naming_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+)
+
+func TestSandboxNameRoundTrip(t *testing.T) {
+	config := makeSandboxConfig("foo", "bar", "iamuid", 3)
+	actualName := makeSandboxName(config)
+	assert.Equal(t, "k8s_POD_foo_bar_iamuid_3", actualName)
+
+	actualMetadata, err := parseSandboxName(actualName)
+	assert.NoError(t, err)
+	assert.Equal(t, config.Metadata, actualMetadata)
+}
+
+func TestNonParsableSandboxNames(t *testing.T) {
+	// All names must start with the kubernetes prefix "k8s".
+	_, err := parseSandboxName("owner_POD_foo_bar_iamuid_4")
+	assert.Error(t, err)
+
+	// All names must contain exactly 6 parts.
+	_, err = parseSandboxName("k8s_POD_dummy_foo_bar_iamuid_4")
+	assert.Error(t, err)
+	_, err = parseSandboxName("k8s_foo_bar_iamuid_4")
+	assert.Error(t, err)
+
+	// Should be able to parse attempt number.
+	_, err = parseSandboxName("k8s_POD_foo_bar_iamuid_notanumber")
+	assert.Error(t, err)
+}
+
+func TestContainerNameRoundTrip(t *testing.T) {
+	sConfig := makeSandboxConfig("foo", "bar", "iamuid", 3)
+	name, attempt := "pause", uint32(5)
+	config := &runtimeapi.ContainerConfig{
+		Metadata: &runtimeapi.ContainerMetadata{
+			Name:    name,
+			Attempt: attempt,
+		},
+	}
+	actualName := makeContainerName(sConfig, config)
+	assert.Equal(t, "k8s_pause_foo_bar_iamuid_5", actualName)
+
+	actualMetadata, err := parseContainerName(actualName)
+	assert.NoError(t, err)
+	assert.Equal(t, config.Metadata, actualMetadata)
+}
+
+func TestNonParsableContainerNames(t *testing.T) {
+	// All names must start with the kubernetes prefix "k8s".
+	_, err := parseContainerName("owner_frontend_foo_bar_iamuid_4")
+	assert.Error(t, err)
+
+	// All names must contain exactly 6 parts.
+	_, err = parseContainerName("k8s_frontend_dummy_foo_bar_iamuid_4")
+	assert.Error(t, err)
+	_, err = parseContainerName("k8s_foo_bar_iamuid_4")
+	assert.Error(t, err)
+
+	// Should be able to parse attempt number.
+	_, err = parseContainerName("k8s_frontend_foo_bar_iamuid_notanumber")
+	assert.Error(t, err)
+}
+
+func TestParseRandomizedNames(t *testing.T) {
+	// Test randomized sandbox name.
+	sConfig := makeSandboxConfig("foo", "bar", "iamuid", 3)
+	sActualName := randomizeName(makeSandboxName(sConfig))
+	sActualMetadata, err := parseSandboxName(sActualName)
+	assert.NoError(t, err)
+	assert.Equal(t, sConfig.Metadata, sActualMetadata)
+
+	// Test randomized container name.
+	name, attempt := "pause", uint32(5)
+	config := &runtimeapi.ContainerConfig{
+		Metadata: &runtimeapi.ContainerMetadata{
+			Name:    name,
+			Attempt: attempt,
+		},
+	}
+	actualName := randomizeName(makeContainerName(sConfig, config))
+	actualMetadata, err := parseContainerName(actualName)
+	assert.NoError(t, err)
+	assert.Equal(t, config.Metadata, actualMetadata)
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/security_context_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/security_context_test.go
@@ -1,0 +1,423 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/blang/semver"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+)
+
+func TestModifyContainerConfig(t *testing.T) {
+	var uid int64 = 123
+	var username = "testuser"
+
+	cases := []struct {
+		name     string
+		sc       *runtimeapi.LinuxContainerSecurityContext
+		expected *dockercontainer.Config
+	}{
+		{
+			name: "container.SecurityContext.RunAsUser set",
+			sc: &runtimeapi.LinuxContainerSecurityContext{
+				RunAsUser: &runtimeapi.Int64Value{Value: uid},
+			},
+			expected: &dockercontainer.Config{
+				User: strconv.FormatInt(uid, 10),
+			},
+		},
+		{
+			name: "container.SecurityContext.RunAsUsername set",
+			sc: &runtimeapi.LinuxContainerSecurityContext{
+				RunAsUsername: username,
+			},
+			expected: &dockercontainer.Config{
+				User: username,
+			},
+		},
+		{
+			name:     "no RunAsUser value set",
+			sc:       &runtimeapi.LinuxContainerSecurityContext{},
+			expected: &dockercontainer.Config{},
+		},
+	}
+
+	for _, tc := range cases {
+		dockerCfg := &dockercontainer.Config{}
+		modifyContainerConfig(tc.sc, dockerCfg)
+		assert.Equal(t, tc.expected, dockerCfg, "[Test case %q]", tc.name)
+	}
+}
+
+func TestModifyHostConfig(t *testing.T) {
+	setNetworkHC := &dockercontainer.HostConfig{}
+	setPrivSC := &runtimeapi.LinuxContainerSecurityContext{}
+	setPrivSC.Privileged = true
+	setPrivHC := &dockercontainer.HostConfig{
+		Privileged: true,
+	}
+	setCapsHC := &dockercontainer.HostConfig{
+		CapAdd:  []string{"addCapA", "addCapB"},
+		CapDrop: []string{"dropCapA", "dropCapB"},
+	}
+	setSELinuxHC := &dockercontainer.HostConfig{
+		SecurityOpt: []string{
+			fmt.Sprintf("%s:%s", selinuxLabelUser('='), "user"),
+			fmt.Sprintf("%s:%s", selinuxLabelRole('='), "role"),
+			fmt.Sprintf("%s:%s", selinuxLabelType('='), "type"),
+			fmt.Sprintf("%s:%s", selinuxLabelLevel('='), "level"),
+		},
+	}
+
+	cases := []struct {
+		name     string
+		sc       *runtimeapi.LinuxContainerSecurityContext
+		expected *dockercontainer.HostConfig
+	}{
+		{
+			name:     "fully set container.SecurityContext",
+			sc:       fullValidSecurityContext(),
+			expected: fullValidHostConfig(),
+		},
+		{
+			name:     "empty container.SecurityContext",
+			sc:       &runtimeapi.LinuxContainerSecurityContext{},
+			expected: setNetworkHC,
+		},
+		{
+			name:     "container.SecurityContext.Privileged",
+			sc:       setPrivSC,
+			expected: setPrivHC,
+		},
+		{
+			name: "container.SecurityContext.Capabilities",
+			sc: &runtimeapi.LinuxContainerSecurityContext{
+				Capabilities: inputCapabilities(),
+			},
+			expected: setCapsHC,
+		},
+		{
+			name: "container.SecurityContext.SELinuxOptions",
+			sc: &runtimeapi.LinuxContainerSecurityContext{
+				SelinuxOptions: inputSELinuxOptions(),
+			},
+			expected: setSELinuxHC,
+		},
+	}
+
+	for _, tc := range cases {
+		dockerCfg := &dockercontainer.HostConfig{}
+		modifyHostConfig(tc.sc, dockerCfg, '=')
+		assert.Equal(t, tc.expected, dockerCfg, "[Test case %q]", tc.name)
+	}
+}
+
+func TestModifyHostConfigWithGroups(t *testing.T) {
+	supplementalGroupsSC := &runtimeapi.LinuxContainerSecurityContext{}
+	supplementalGroupsSC.SupplementalGroups = []int64{2222}
+	supplementalGroupHC := &dockercontainer.HostConfig{}
+	supplementalGroupHC.GroupAdd = []string{"2222"}
+
+	testCases := []struct {
+		name            string
+		securityContext *runtimeapi.LinuxContainerSecurityContext
+		expected        *dockercontainer.HostConfig
+	}{
+		{
+			name:            "nil",
+			securityContext: nil,
+			expected:        &dockercontainer.HostConfig{},
+		},
+		{
+			name:            "SupplementalGroup",
+			securityContext: supplementalGroupsSC,
+			expected:        supplementalGroupHC,
+		},
+	}
+
+	for _, tc := range testCases {
+		dockerCfg := &dockercontainer.HostConfig{}
+		modifyHostConfig(tc.securityContext, dockerCfg, '=')
+		assert.Equal(t, tc.expected, dockerCfg, "[Test case %q]", tc.name)
+	}
+}
+
+func TestModifyHostConfigAndNamespaceOptionsForContainer(t *testing.T) {
+	priv := true
+	sandboxID := "sandbox"
+	sandboxNSMode := fmt.Sprintf("container:%v", sandboxID)
+	setPrivSC := &runtimeapi.LinuxContainerSecurityContext{}
+	setPrivSC.Privileged = priv
+	setPrivHC := &dockercontainer.HostConfig{
+		Privileged:  true,
+		IpcMode:     dockercontainer.IpcMode(sandboxNSMode),
+		NetworkMode: dockercontainer.NetworkMode(sandboxNSMode),
+		PidMode:     dockercontainer.PidMode(sandboxNSMode),
+	}
+	setCapsHC := &dockercontainer.HostConfig{
+		CapAdd:      []string{"addCapA", "addCapB"},
+		CapDrop:     []string{"dropCapA", "dropCapB"},
+		IpcMode:     dockercontainer.IpcMode(sandboxNSMode),
+		NetworkMode: dockercontainer.NetworkMode(sandboxNSMode),
+		PidMode:     dockercontainer.PidMode(sandboxNSMode),
+	}
+	setSELinuxHC := &dockercontainer.HostConfig{
+		SecurityOpt: []string{
+			fmt.Sprintf("%s:%s", selinuxLabelUser('='), "user"),
+			fmt.Sprintf("%s:%s", selinuxLabelRole('='), "role"),
+			fmt.Sprintf("%s:%s", selinuxLabelType('='), "type"),
+			fmt.Sprintf("%s:%s", selinuxLabelLevel('='), "level"),
+		},
+		IpcMode:     dockercontainer.IpcMode(sandboxNSMode),
+		NetworkMode: dockercontainer.NetworkMode(sandboxNSMode),
+		PidMode:     dockercontainer.PidMode(sandboxNSMode),
+	}
+
+	cases := []struct {
+		name     string
+		sc       *runtimeapi.LinuxContainerSecurityContext
+		expected *dockercontainer.HostConfig
+	}{
+		{
+			name:     "container.SecurityContext.Privileged",
+			sc:       setPrivSC,
+			expected: setPrivHC,
+		},
+		{
+			name: "container.SecurityContext.Capabilities",
+			sc: &runtimeapi.LinuxContainerSecurityContext{
+				Capabilities: inputCapabilities(),
+			},
+			expected: setCapsHC,
+		},
+		{
+			name: "container.SecurityContext.SELinuxOptions",
+			sc: &runtimeapi.LinuxContainerSecurityContext{
+				SelinuxOptions: inputSELinuxOptions(),
+			},
+			expected: setSELinuxHC,
+		},
+	}
+
+	for _, tc := range cases {
+		dockerCfg := &dockercontainer.HostConfig{}
+		modifyHostConfig(tc.sc, dockerCfg, '=')
+		modifyContainerNamespaceOptions(tc.sc.GetNamespaceOptions(), sandboxID, dockerCfg)
+		assert.Equal(t, tc.expected, dockerCfg, "[Test case %q]", tc.name)
+	}
+}
+
+func TestModifySandboxNamespaceOptions(t *testing.T) {
+	set := true
+	cases := []struct {
+		name     string
+		nsOpt    *runtimeapi.NamespaceOption
+		expected *dockercontainer.HostConfig
+	}{
+		{
+			name: "NamespaceOption.HostNetwork",
+			nsOpt: &runtimeapi.NamespaceOption{
+				HostNetwork: set,
+			},
+			expected: &dockercontainer.HostConfig{
+				NetworkMode: namespaceModeHost,
+			},
+		},
+		{
+			name: "NamespaceOption.HostIpc",
+			nsOpt: &runtimeapi.NamespaceOption{
+				HostIpc: set,
+			},
+			expected: &dockercontainer.HostConfig{
+				IpcMode:     namespaceModeHost,
+				NetworkMode: "default",
+			},
+		},
+		{
+			name: "NamespaceOption.HostPid",
+			nsOpt: &runtimeapi.NamespaceOption{
+				HostPid: set,
+			},
+			expected: &dockercontainer.HostConfig{
+				PidMode:     namespaceModeHost,
+				NetworkMode: "default",
+			},
+		},
+	}
+	for _, tc := range cases {
+		dockerCfg := &dockercontainer.HostConfig{}
+		modifySandboxNamespaceOptions(tc.nsOpt, dockerCfg, nil)
+		assert.Equal(t, tc.expected, dockerCfg, "[Test case %q]", tc.name)
+	}
+}
+
+func TestModifyContainerNamespaceOptions(t *testing.T) {
+	set := true
+	sandboxID := "sandbox"
+	sandboxNSMode := fmt.Sprintf("container:%v", sandboxID)
+	cases := []struct {
+		name     string
+		nsOpt    *runtimeapi.NamespaceOption
+		expected *dockercontainer.HostConfig
+	}{
+		{
+			name: "NamespaceOption.HostNetwork",
+			nsOpt: &runtimeapi.NamespaceOption{
+				HostNetwork: set,
+			},
+			expected: &dockercontainer.HostConfig{
+				NetworkMode: dockercontainer.NetworkMode(sandboxNSMode),
+				IpcMode:     dockercontainer.IpcMode(sandboxNSMode),
+				UTSMode:     namespaceModeHost,
+				PidMode:     dockercontainer.PidMode(sandboxNSMode),
+			},
+		},
+		{
+			name: "NamespaceOption.HostIpc",
+			nsOpt: &runtimeapi.NamespaceOption{
+				HostIpc: set,
+			},
+			expected: &dockercontainer.HostConfig{
+				NetworkMode: dockercontainer.NetworkMode(sandboxNSMode),
+				IpcMode:     dockercontainer.IpcMode(sandboxNSMode),
+				PidMode:     dockercontainer.PidMode(sandboxNSMode),
+			},
+		},
+		{
+			name: "NamespaceOption.HostPid",
+			nsOpt: &runtimeapi.NamespaceOption{
+				HostPid: set,
+			},
+			expected: &dockercontainer.HostConfig{
+				NetworkMode: dockercontainer.NetworkMode(sandboxNSMode),
+				IpcMode:     dockercontainer.IpcMode(sandboxNSMode),
+				PidMode:     namespaceModeHost,
+			},
+		},
+	}
+	for _, tc := range cases {
+		dockerCfg := &dockercontainer.HostConfig{}
+		modifyContainerNamespaceOptions(tc.nsOpt, sandboxID, dockerCfg)
+		assert.Equal(t, tc.expected, dockerCfg, "[Test case %q]", tc.name)
+	}
+}
+
+func TestModifyContainerNamespacePIDOverride(t *testing.T) {
+	cases := []struct {
+		name            string
+		disable         bool
+		version         *semver.Version
+		input, expected dockercontainer.PidMode
+	}{
+		{
+			name:     "SharedPID.Enable",
+			disable:  false,
+			version:  &semver.Version{Major: 1, Minor: 26},
+			input:    "container:sandbox",
+			expected: "container:sandbox",
+		},
+		{
+			name:     "SharedPID.Disable",
+			disable:  true,
+			version:  &semver.Version{Major: 1, Minor: 26},
+			input:    "container:sandbox",
+			expected: "",
+		},
+		{
+			name:     "SharedPID.OldDocker",
+			disable:  false,
+			version:  &semver.Version{Major: 1, Minor: 25},
+			input:    "container:sandbox",
+			expected: "",
+		},
+		{
+			name:     "SharedPID.HostPid",
+			disable:  true,
+			version:  &semver.Version{Major: 1, Minor: 27},
+			input:    "host",
+			expected: "host",
+		},
+		{
+			name:     "SharedPID.DistantFuture",
+			disable:  false,
+			version:  &semver.Version{Major: 2, Minor: 10},
+			input:    "container:sandbox",
+			expected: "container:sandbox",
+		},
+		{
+			name:     "SharedPID.EmptyPidMode",
+			disable:  true,
+			version:  &semver.Version{Major: 1, Minor: 25},
+			input:    "",
+			expected: "",
+		},
+	}
+	for _, tc := range cases {
+		dockerCfg := &dockercontainer.HostConfig{PidMode: tc.input}
+		modifyPIDNamespaceOverrides(tc.disable, tc.version, dockerCfg)
+		assert.Equal(t, tc.expected, dockerCfg.PidMode, "[Test case %q]", tc.name)
+	}
+}
+
+func fullValidSecurityContext() *runtimeapi.LinuxContainerSecurityContext {
+	return &runtimeapi.LinuxContainerSecurityContext{
+		Privileged:     true,
+		Capabilities:   inputCapabilities(),
+		SelinuxOptions: inputSELinuxOptions(),
+	}
+}
+
+func inputCapabilities() *runtimeapi.Capability {
+	return &runtimeapi.Capability{
+		AddCapabilities:  []string{"addCapA", "addCapB"},
+		DropCapabilities: []string{"dropCapA", "dropCapB"},
+	}
+}
+
+func inputSELinuxOptions() *runtimeapi.SELinuxOption {
+	user := "user"
+	role := "role"
+	stype := "type"
+	level := "level"
+
+	return &runtimeapi.SELinuxOption{
+		User:  user,
+		Role:  role,
+		Type:  stype,
+		Level: level,
+	}
+}
+
+func fullValidHostConfig() *dockercontainer.HostConfig {
+	return &dockercontainer.HostConfig{
+		Privileged: true,
+		CapAdd:     []string{"addCapA", "addCapB"},
+		CapDrop:    []string{"dropCapA", "dropCapB"},
+		SecurityOpt: []string{
+			fmt.Sprintf("%s:%s", selinuxLabelUser('='), "user"),
+			fmt.Sprintf("%s:%s", selinuxLabelRole('='), "role"),
+			fmt.Sprintf("%s:%s", selinuxLabelType('='), "type"),
+			fmt.Sprintf("%s:%s", selinuxLabelLevel('='), "level"),
+		},
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/selinux_util_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/selinux_util_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestModifySecurityOptions(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   []string
+		optName  string
+		optVal   string
+		expected []string
+	}{
+		{
+			name:     "Empty val",
+			config:   []string{"a:b", "c:d"},
+			optName:  "optA",
+			optVal:   "",
+			expected: []string{"a:b", "c:d"},
+		},
+		{
+			name:     "Valid",
+			config:   []string{"a:b", "c:d"},
+			optName:  "e",
+			optVal:   "f",
+			expected: []string{"a:b", "c:d", "e:f"},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := modifySecurityOption(tc.config, tc.optName, tc.optVal)
+		if !reflect.DeepEqual(tc.expected, actual) {
+			t.Errorf("Failed to apply options correctly for tc: %s.  Expected: %v but got %v", tc.name, tc.expected, actual)
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -4030,34 +4030,34 @@
 			"revisionTime": "2017-11-15T14:41:05Z"
 		},
 		{
-			"checksumSHA1": "DPMriBhrNK0onGxgiqDFTlMG0n8=",
+			"checksumSHA1": "+Ro+EzhwFkSePw/mfk5bEv5vrEI=",
 			"path": "k8s.io/kubernetes/pkg/kubelet/dockershim",
-			"revision": "1ced91f2011b6d20a9572cf782762a1ca5da05c0",
-			"revisionTime": "2017-11-15T14:41:05Z"
+			"revision": "5fa2db2bd46ac79e5e00a4e6ed24191080aa463b",
+			"revisionTime": "2018-01-17T11:44:51Z"
 		},
 		{
 			"checksumSHA1": "oAd+2EDHVy/uczGXG2qMk9shxw8=",
 			"path": "k8s.io/kubernetes/pkg/kubelet/dockershim/cm",
-			"revision": "1ced91f2011b6d20a9572cf782762a1ca5da05c0",
-			"revisionTime": "2017-11-15T14:41:05Z"
+			"revision": "5fa2db2bd46ac79e5e00a4e6ed24191080aa463b",
+			"revisionTime": "2018-01-17T11:44:51Z"
 		},
 		{
-			"checksumSHA1": "mNcKzj7E7fxQf4PaLsqiICcL8VE=",
+			"checksumSHA1": "1AVPlCXu7VxaLsDY+2GbE1bdpvg=",
 			"path": "k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker",
-			"revision": "1ced91f2011b6d20a9572cf782762a1ca5da05c0",
-			"revisionTime": "2017-11-15T14:41:05Z"
+			"revision": "5fa2db2bd46ac79e5e00a4e6ed24191080aa463b",
+			"revisionTime": "2018-01-17T11:44:51Z"
 		},
 		{
 			"checksumSHA1": "/GQpvIUql5XSYXRWpowjUhWEHmY=",
 			"path": "k8s.io/kubernetes/pkg/kubelet/dockershim/metrics",
-			"revision": "1ced91f2011b6d20a9572cf782762a1ca5da05c0",
-			"revisionTime": "2017-11-15T14:41:05Z"
+			"revision": "5fa2db2bd46ac79e5e00a4e6ed24191080aa463b",
+			"revisionTime": "2018-01-17T11:44:51Z"
 		},
 		{
 			"checksumSHA1": "lnwoSE0Sht70ys4ylVQvz/l+fW0=",
 			"path": "k8s.io/kubernetes/pkg/kubelet/dockershim/remote",
-			"revision": "1ced91f2011b6d20a9572cf782762a1ca5da05c0",
-			"revisionTime": "2017-11-15T14:41:05Z"
+			"revision": "5fa2db2bd46ac79e5e00a4e6ed24191080aa463b",
+			"revisionTime": "2018-01-17T11:44:51Z"
 		},
 		{
 			"checksumSHA1": "NnvlMZE+sbgDHaBvtq2Pad9mCRc=",
@@ -4829,5 +4829,5 @@
 			"revisionTime": "2017-07-19T03:11:28Z"
 		}
 	],
-	"rootPath": "k8s.io/frakti"
+	"rootPath": "/k8s.io/frakti"
 }


### PR DESCRIPTION
## 1.Describe what this PR did
Upgrade vendored dockershim to v1.9.2

## 2.Does this pull request fix one issue?
#287 

## 3.Describe how you did it
update vendored dockershim to v1.9.2

## 4.Describe how to verify it
### **cri-tool(v0.2):** 
[root@frakti1 critest]# ./critest -r=/var/run/frakti.sock --focus="Conformance" --skip="port mapping" validation

Summarizing 2 Failures:

[Fail] [k8s.io] Image Manager [It] public image with digest should be pulled and removed [Conformance] 
/root/go/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/util.go:237

[Fail] [k8s.io] Container runtime should support adding volume and device [Conformance] [It] runtime should support starting container with volume when host path doesn't exist 
/root/go/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/util.go:202

Ran 22 of 54 Specs in 157.961 seconds
FAIL! -- 20 Passed | 2 Failed | 0 Pending | 32 Skipped --- FAIL: TestE2ECRI (157.97s)
FAIL

### **Kubernetes**:
**runtime-docker:**
[root@frakti1 ~]# cat frakti-docker.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: frakti-docker
  namespace: default
  labels:
    frakti: frakti
spec:
  selector:
    matchLabels:
      frakti: frakti
  template:
    metadata:
      _annotations:
        runtime.frakti.alpha.kubernetes.io/OSContainer: "true"_
      labels:
        frakti: frakti
    spec:
      containers:
      - name: frakti
        image: gcr.io/google_containers/nginx

[root@frakti1 ~]# kubectl create -f frakti-docker.yaml 
deployment "frakti-docker" created

[root@frakti1 ~]# kubectl get pod
NAME                           READY     STATUS    RESTARTS   AGE
frakti-docker-94c545b5-rv84f   1/1       Running   0          1m

[root@frakti1 ~]# docker ps | grep frakti-docker
335a696018bf        gcr.io/google_containers/nginx@sha256:f49a843c290594dcf4d193535d1f4ba8af7d56cea2cf79d1e9554f077f1e7aaa   "nginx"                  About a minute ago   Up About a minute                       k8s_frakti_frakti-docker-9
4c545b5-rv84f_default_94d0c77d-0f20-11e8-8c0c-42010a8c0002_0
8a9f37809d32        gcr.io/google_containers/pause-amd64:3.0                                                                 "/pause"                 About a minute ago   Up About a minute                       k8s_POD_frakti-docker-94c5
45b5-rv84f_default_94d0c77d-0f20-11e8-8c0c-42010a8c0002_0

**runtime-hyperd:**
[root@frakti1 ~]# cat frakti-hyperd.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: fraktihy
  namespace: default
  labels:
    frakti: fraktihy
spec:
  selector:
    matchLabels:
      frakti: fraktihy
  template:
    metadata:
      labels:
        frakti: fraktihy
    spec:
      containers:
      - name: frakti
        image: gcr.io/google_containers/nginx

[root@frakti1 ~]# kubectl create -f frakti-hyperd.yaml 
deployment "fraktihy" created

[root@frakti1 ~]# kubectl get pod
NAME                           READY     STATUS    RESTARTS   AGE
frakti-docker-94c545b5-rv84f   1/1       Running   0          2m
fraktihy-78fd8b8878-lctlf      1/1       Running   0          16s

[root@frakti1 ~]# hyperctl list
POD ID                                                                                      POD Name                                                                                    VM name             Status
k8s_POD.0_fraktihy-78fd8b8878-lctlf_default_e8250c60-0f20-11e8-8c0c-42010a8c0002_40cf8a97   k8s_POD.0_fraktihy-78fd8b8878-lctlf_default_e8250c60-0f20-11e8-8c0c-42010a8c0002_40cf8a97   vm-mHBhInMCIK       running

## 5.Special notes for reviews
NONE