### PR TITLE
Fix url

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -93,7 +93,7 @@ systemctl start docker
 #### Install frakti
 
 ```sh
-curl -sSL https://github.com/kubernetes/frakti/releases/download/v1.9/frakti -o /usr/bin/frakti
+curl -sSL https://github.com/kubernetes/frakti/releases/download/1.9/frakti -o /usr/bin/frakti
 chmod +x /usr/bin/frakti
 cgroup_driver=$(docker info | awk '/Cgroup Driver/{print $3}')
 cat <<EOF > /lib/systemd/system/frakti.service

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -13,7 +13,7 @@ Firstly, install CNI:
 
 ```sh
 $ sudo mkdir -p /etc/cni/net.d  /opt/cni/bin
-$ git clone https://github.com/containernetworking/plugins $GOPATH/src/github.com/containernetworking/plugins
+$ git clone https://github.com/containernetworking/plugins.git $GOPATH/src/github.com/containernetworking/plugins
 $ cd $GOPATH/src/github.com/containernetworking/plugins
 $ ./build.sh
 $ sudo cp bin/* /opt/cni/bin/


### PR DESCRIPTION
fix frakti download link error in frakti/docs/deploy.md 
chaned https://github.com/kubernetes/frakti/releases/download/v1.9/frakti
to         https://github.com/kubernetes/frakti/releases/download/1.9/frakti

```release-note
None
```