### PR TITLE
Implement runtime's fundamental functions

### DIFF
--- a/pkg/kata/proc/exec.go
+++ b/pkg/kata/proc/exec.go
@@ -25,18 +25,20 @@ import (
 
 	"github.com/containerd/console"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 )
 
-type execProcess struct {
+type ExecProcess struct {
 	wg sync.WaitGroup
 
 	State
 
-	mu         sync.Mutex
-	id         string
-	pid        int
+	mu    sync.Mutex
+	id    string
+	pid   int
+	token string
 
 	exitStatus int
 	exited     time.Time
@@ -53,61 +55,67 @@ type execProcess struct {
 	sandbox vc.VCSandbox
 }
 
-func (e *execProcess) ID() string {
+func (e *ExecProcess) ID() string {
 	return e.id
 }
 
-func (e *execProcess) Pid() int {
+func (e *ExecProcess) Pid() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.pid
 }
 
-func (e *execProcess) ExitStatus() int {
+func (e *ExecProcess) ExitStatus() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.exitStatus
 }
 
-func (e *execProcess) ExitedAt() time.Time {
+func (e *ExecProcess) ExitedAt() time.Time {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.exited
 }
 
-func (e *execProcess) Stdin() io.Closer {
+func (e *ExecProcess) Stdin() io.Closer {
 	return e.stdin
 }
 
-func (e *execProcess) Stdio() Stdio {
+func (e *ExecProcess) Stdio() Stdio {
 	return e.stdio
 }
 
-func (e *execProcess) Status(ctx context.Context) (string, error) {
-	return "", fmt.Errorf("exec process status is not implemented")
+func (e *ExecProcess) Status(ctx context.Context) (string, error) {
+	s, err := e.parent.Status(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return s, nil
 }
 
-func (e *execProcess) Wait() {
+func (e *ExecProcess) Wait() {
 	<-e.waitBlock
 }
 
-func (e *execProcess) resize(ws console.WinSize) error {
-	return fmt.Errorf("exec process resize is not implemented")
+func (e *ExecProcess) resize(ws console.WinSize) error {
+	sandbox := e.parent.sandbox
+	err := sandbox.WinsizeProcess(sandbox.ID(), e.token, uint32(ws.Height), uint32(ws.Width))
+	if err != nil {
+		return errors.Wrap(err, "failed to resize")
+	}
+	return nil
 }
 
-func (e *execProcess) start(ctx context.Context) error {
-	return fmt.Errorf("exec process start is not implemented")
-}
-
-func (e *execProcess) delete(ctx context.Context) error {
+func (e *ExecProcess) delete(ctx context.Context) error {
 	return fmt.Errorf("exec process delete is not implemented")
 }
 
-func (e *execProcess) kill(ctx context.Context, sig uint32, _ bool) error {
+func (e *ExecProcess) kill(ctx context.Context, sig uint32, _ bool) error {
 	return fmt.Errorf("exec process kill is not implemented")
 }
 
-func (e *execProcess) setExited(status int) {
+func (e *ExecProcess) setExited(status int) {
 	e.exitStatus = status
 	e.exited = time.Now()
 	close(e.waitBlock)

--- a/pkg/kata/proc/exec.go
+++ b/pkg/kata/proc/exec.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/containerd/console"
@@ -108,7 +109,12 @@ func (e *ExecProcess) resize(ws console.WinSize) error {
 }
 
 func (e *ExecProcess) delete(ctx context.Context) error {
-	return fmt.Errorf("exec process delete is not implemented")
+	sandbox := e.parent.sandbox
+	err := sandbox.SignalProcess(sandbox.ID(), e.token, syscall.SIGKILL, false)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete exec process")
+	}
+	return nil
 }
 
 func (e *ExecProcess) kill(ctx context.Context, sig uint32, _ bool) error {

--- a/pkg/kata/proc/exec.go
+++ b/pkg/kata/proc/exec.go
@@ -95,8 +95,9 @@ func (e *ExecProcess) Status(ctx context.Context) (string, error) {
 	return s, nil
 }
 
-func (e *ExecProcess) Wait() {
+func (e *ExecProcess) Wait(ctx context.Context) (int, error) {
 	<-e.waitBlock
+	return -1, nil
 }
 
 func (e *ExecProcess) resize(ws console.WinSize) error {
@@ -124,5 +125,5 @@ func (e *ExecProcess) kill(ctx context.Context, sig uint32, _ bool) error {
 func (e *ExecProcess) setExited(status int) {
 	e.exitStatus = status
 	e.exited = time.Now()
-	close(e.waitBlock)
+	// close(e.waitBlock)
 }

--- a/pkg/kata/proc/exec.go
+++ b/pkg/kata/proc/exec.go
@@ -25,10 +25,9 @@ import (
 	"time"
 
 	"github.com/containerd/console"
+	vc "github.com/kata-containers/runtime/virtcontainers"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-
-	vc "github.com/kata-containers/runtime/virtcontainers"
 )
 
 type ExecProcess struct {

--- a/pkg/kata/proc/exec_state.go
+++ b/pkg/kata/proc/exec_state.go
@@ -24,7 +24,7 @@ import (
 )
 
 type execCreatedState struct {
-	p *execProcess
+	p *ExecProcess
 }
 
 func (s *execCreatedState) transition(name string) error {
@@ -46,15 +46,6 @@ func (s *execCreatedState) Resize(ws console.WinSize) error {
 	defer s.p.mu.Unlock()
 
 	return s.p.resize(ws)
-}
-
-func (s *execCreatedState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-	if err := s.p.start(ctx); err != nil {
-		return err
-	}
-	return s.transition("running")
 }
 
 func (s *execCreatedState) Delete(ctx context.Context) error {
@@ -85,7 +76,7 @@ func (s *execCreatedState) SetExited(status int) {
 }
 
 type execRunningState struct {
-	p *execProcess
+	p *ExecProcess
 }
 
 func (s *execRunningState) transition(name string) error {
@@ -103,13 +94,6 @@ func (s *execRunningState) Resize(ws console.WinSize) error {
 	defer s.p.mu.Unlock()
 
 	return s.p.resize(ws)
-}
-
-func (s *execRunningState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
-	return errors.Errorf("cannot start a running process")
 }
 
 func (s *execRunningState) Delete(ctx context.Context) error {
@@ -138,7 +122,7 @@ func (s *execRunningState) SetExited(status int) {
 }
 
 type execStoppedState struct {
-	p *execProcess
+	p *ExecProcess
 }
 
 func (s *execStoppedState) transition(name string) error {
@@ -156,13 +140,6 @@ func (s *execStoppedState) Resize(ws console.WinSize) error {
 	defer s.p.mu.Unlock()
 
 	return errors.Errorf("cannot resize a stopped container")
-}
-
-func (s *execStoppedState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
-	return errors.Errorf("cannot start a stopped process")
 }
 
 func (s *execStoppedState) Delete(ctx context.Context) error {

--- a/pkg/kata/proc/init.go
+++ b/pkg/kata/proc/init.go
@@ -29,16 +29,13 @@ import (
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/fifo"
+	"github.com/containerd/cri/pkg/annotations"
+	vc "github.com/kata-containers/runtime/virtcontainers"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-
-	"github.com/containerd/containerd/runtime/kata/server"
-
-	vc "github.com/kata-containers/runtime/virtcontainers"
-
 	"github.com/sirupsen/logrus"
-
-	"github.com/containerd/cri/pkg/annotations"
+	"k8s.io/frakti/pkg/kata/server"
 )
 
 // InitPidFile name of the file that contains the init pid
@@ -301,7 +298,7 @@ func (p *Init) Wait(ctx context.Context) (int, error) {
 	// after exiting process, the container will be stopped.
 	_, err = vc.StopContainer(p.sandboxID, p.id)
 	if err != nil {
-		return err
+		return -1, err
 	}
 
 	return int(exitCode), nil

--- a/pkg/kata/proc/init.go
+++ b/pkg/kata/proc/init.go
@@ -19,7 +19,6 @@ package proc
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -33,13 +32,24 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 
-	"k8s.io/frakti/pkg/kata/server"
+	"github.com/containerd/containerd/runtime/kata/server"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/cri/pkg/annotations"
 )
 
 // InitPidFile name of the file that contains the init pid
 const InitPidFile = "init.pid"
+
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		buffer := make([]byte, 32<<10)
+		return &buffer
+	},
+}
 
 // Init represents an initial process for a container
 type Init struct {
@@ -54,6 +64,9 @@ type Init struct {
 	id     string
 	bundle string
 
+	containerType string
+	sandboxID     string
+
 	exitStatus int
 	exited     time.Time
 	pid        int
@@ -65,7 +78,8 @@ type Init struct {
 	IoUID      int
 	IoGID      int
 
-	sandbox vc.VCSandbox
+	sandbox   *vc.Sandbox
+	container *vc.Container
 }
 
 // NewInit returns a new init process
@@ -97,8 +111,10 @@ func NewInit(ctx context.Context, path, workDir, namespace string, pid int, conf
 	}
 
 	p := &Init{
-		id:  config.ID,
-		pid: pid,
+		id:            config.ID,
+		pid:           pid,
+		sandboxID:     config.SandboxID,
+		containerType: config.ContainerType,
 		stdio: Stdio{
 			Stdin:    config.Stdin,
 			Stdout:   config.Stdout,
@@ -115,19 +131,19 @@ func NewInit(ctx context.Context, path, workDir, namespace string, pid int, conf
 	}
 	p.initState = &createdState{p: p}
 
-	// create kata container
-	p.sandbox, err = server.CreateSandbox(ctx, config.ID)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create sandbox")
+	if p.containerType == annotations.ContainerTypeSandbox {
+		p.sandbox, err = server.CreateSandbox(config.ID)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create sandbox")
+		}
+	} else if p.containerType == annotations.ContainerTypeContainer {
+		p.sandbox, p.container, err = server.CreateContainer(p.id, p.sandboxID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create container")
+		}
+	} else {
+		return nil, errors.New(ErrContainerType)
 	}
-
-	stdin, stdout, stderr, err := p.sandbox.IOStream(config.ID, config.ID)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get a container's stdio streams from kata")
-	}
-	p.stdin = stdin
-	p.stdout = stdout
-	p.stderr = stderr
 
 	// TODO(ZeroMagic): create with checkpoint
 
@@ -173,14 +189,25 @@ func (p *Init) Stdio() Stdio {
 func (p *Init) Status(ctx context.Context) (string, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	status, err := server.StatusContainer(p.sandbox.ID(), p.sandbox.ID())
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "stopped", nil
+
+	if p.containerType == annotations.ContainerTypeSandbox {
+		status, err := vc.StatusSandbox(p.id)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "stopped", nil
+			}
+			return "", errors.Wrap(err, "failed to get status of sandbox")
 		}
-		return "", errors.Wrap(err, "OCI runtime state failed")
+		logrus.FieldLogger(logrus.New()).Infof("[Init] sandbox status: %v", status.State.State)
+		return string(status.State.State), nil
+	} else {
+		status, err := vc.StatusContainer(p.sandboxID, p.id)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to get status of container")
+		}
+		return string(status.State.State), nil
 	}
-	return string(status.State.State), nil
+
 }
 
 // Wait for the process to exit
@@ -193,23 +220,59 @@ func (p *Init) resize(ws console.WinSize) error {
 }
 
 func (p *Init) start(ctx context.Context) error {
-	err := server.StartSandbox(ctx, p.sandbox.ID())
-	if err != nil {
-		return errors.Wrap(err, "failed to start sandbox")
+	var err error
+	if p.containerType == annotations.ContainerTypeSandbox {
+		p.sandbox, err = server.StartSandbox(p.id)
+		if err != nil {
+			return errors.Wrap(err, "failed to start sandbox")
+		}
+	} else if p.containerType == annotations.ContainerTypeContainer {
+		p.container, err = server.StartContainer(p.id, p.sandboxID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to start container")
+		}
+	} else {
+		return errors.New(ErrContainerType)
 	}
 
 	return nil
 }
 
 func (p *Init) delete(ctx context.Context) error {
-	return fmt.Errorf("init process delete is not implemented")
+	logrus.FieldLogger(logrus.New()).Infof("[init] delete %s", p.id)
+
+	if p.containerType == annotations.ContainerTypeSandbox {
+		_, err := vc.DeleteSandbox(p.id)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete sandbox")
+		}
+	} else {
+		_, err := vc.DeleteContainer(p.sandboxID, p.id)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete container")
+		}
+	}
+
+	return nil
 }
 
 func (p *Init) kill(ctx context.Context, signal uint32, all bool) error {
-
-	err := server.KillContainer(p.sandbox.ID(), p.sandbox.ID(), syscall.Signal(signal), all)
-	if err != nil {
-		return errors.Wrap(err, "failed to kill container")
+	if p.containerType == annotations.ContainerTypeSandbox {
+		sandbox, err := vc.StopSandbox(p.sandboxID)
+		if err != nil {
+			return errors.Wrap(err, "failed to stop sandbox")
+		}
+		p.sandbox = sandbox.(*vc.Sandbox)
+	} else {
+		err := vc.KillContainer(p.sandboxID, p.id, syscall.Signal(signal), all)
+		if err != nil {
+			return errors.Wrapf(err, "failed to kill container")
+		}
+		_, err = vc.StopContainer(p.sandboxID, p.id)
+		if err != nil {
+			errors.Wrap(err, "failed to stop container")
+			return err
+		}
 	}
 
 	return nil
@@ -275,14 +338,14 @@ func (p *Init) exec(context context.Context, id string, conf *ExecConfig) (Proce
 		NoNewPrivileges: spec.NoNewPrivileges,
 	}
 
-	_, process, err := p.sandbox.EnterContainer(p.sandbox.ID(), cmd)
+	_, process, err := p.sandbox.EnterContainer(p.id, cmd)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot enter container %s", p.sandbox.ID())
+		return nil, errors.Wrapf(err, "cannot enter container %s", p.id)
 	}
 
-	stdin, stdout, stderr, err := p.sandbox.IOStream(p.sandbox.ID(), process.Token)
+	stdin, stdout, stderr, err := p.sandbox.IOStream(p.id, process.Token)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot get %s IOStream", p.sandbox.ID())
+		return nil, errors.Wrapf(err, "cannot get %s IOStream", p.id)
 	}
 
 	e := &ExecProcess{
@@ -299,7 +362,7 @@ func (p *Init) exec(context context.Context, id string, conf *ExecConfig) (Proce
 			Stderr:   conf.Stderr,
 			Terminal: conf.Terminal,
 		},
-		spec:      spec,
+		spec: spec,
 		waitBlock: make(chan struct{}),
 	}
 	e.State = &execCreatedState{p: e}

--- a/pkg/kata/proc/init.go
+++ b/pkg/kata/proc/init.go
@@ -453,7 +453,7 @@ func (p *Init) exec(context context.Context, id string, conf *ExecConfig) (Proce
 			Stderr:   conf.Stderr,
 			Terminal: conf.Terminal,
 		},
-		spec: spec,
+		spec:      spec,
 		waitBlock: make(chan struct{}),
 	}
 	e.State = &execCreatedState{p: e}

--- a/pkg/kata/proc/init_state.go
+++ b/pkg/kata/proc/init_state.go
@@ -26,7 +26,7 @@ import (
 
 type initState interface {
 	State
-	
+
 	Pause(context.Context) error
 	Resume(context.Context) error
 	Start(context.Context) error

--- a/pkg/kata/proc/init_state.go
+++ b/pkg/kata/proc/init_state.go
@@ -29,6 +29,8 @@ type initState interface {
 	
 	Pause(context.Context) error
 	Resume(context.Context) error
+	Start(context.Context) error
+	Exec(context.Context, string, *ExecConfig) (Process, error)
 }
 
 type createdState struct {
@@ -106,6 +108,12 @@ func (s *createdState) Resume(ctx context.Context) error {
 	return errors.Errorf("cannot resume task in created state")
 }
 
+func (s *createdState) Exec(ctx context.Context, id string, conf *ExecConfig) (Process, error) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.exec(ctx, id, conf)
+}
+
 type runningState struct {
 	p *Init
 }
@@ -175,6 +183,12 @@ func (s *runningState) Resume(ctx context.Context) error {
 	defer s.p.mu.Unlock()
 
 	return errors.Errorf("cannot resume a running process")
+}
+
+func (s *runningState) Exec(ctx context.Context, id string, conf *ExecConfig) (Process, error) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.exec(ctx, id, conf)
 }
 
 type pausedState struct {
@@ -249,6 +263,13 @@ func (s *pausedState) Resume(ctx context.Context) error {
 	return s.transition("running")
 }
 
+func (s *pausedState) Exec(ctx context.Context, id string, conf *ExecConfig) (Process, error) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return nil, errors.Errorf("cannot exec in a paused state")
+}
+
 type stoppedState struct {
 	p *Init
 }
@@ -306,4 +327,11 @@ func (s *stoppedState) Resume(ctx context.Context) error {
 	defer s.p.mu.Unlock()
 
 	return errors.Errorf("cannot resume a stopped container")
+}
+
+func (s *stoppedState) Exec(ctx context.Context, id string, conf *ExecConfig) (Process, error) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return nil, errors.Errorf("cannot exec in a stopped state")
 }

--- a/pkg/kata/proc/init_state.go
+++ b/pkg/kata/proc/init_state.go
@@ -155,7 +155,16 @@ func (s *runningState) Kill(ctx context.Context, sig uint32, all bool) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
-	return s.p.kill(ctx, sig, all)
+	err := s.p.kill(ctx, sig, all)
+	if err != nil {
+		return err
+	}
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+
+	return nil
 }
 
 func (s *runningState) SetExited(status int) {

--- a/pkg/kata/proc/process.go
+++ b/pkg/kata/proc/process.go
@@ -64,8 +64,6 @@ type Process interface {
 type State interface {
 	// Resize resizes the process console
 	Resize(ws console.WinSize) error
-	// Start execution of the process
-	Start(context.Context) error
 	// Delete deletes the process and its resourcess
 	Delete(context.Context) error
 	// Kill kills the process

--- a/pkg/kata/proc/process.go
+++ b/pkg/kata/proc/process.go
@@ -57,7 +57,7 @@ type Process interface {
 	// Status returns the process status
 	Status(context.Context) (string, error)
 	// Wait blocks until the process has exited
-	Wait()
+	Wait(context.Context) (int, error)
 }
 
 // State of a process

--- a/pkg/kata/proc/types.go
+++ b/pkg/kata/proc/types.go
@@ -28,15 +28,15 @@ const (
 
 // InitConfig hold task creation configuration
 type InitConfig struct {
-	ID       string
+	ID            string
 	SandboxID     string
 	ContainerType string
-	Runtime  string
-	Rootfs   []mount.Mount
-	Terminal bool
-	Stdin    string
-	Stdout   string
-	Stderr   string
+	Runtime       string
+	Rootfs        []mount.Mount
+	Terminal      bool
+	Stdin         string
+	Stdout        string
+	Stderr        string
 }
 
 // ExecConfig holds exec creation configuration

--- a/pkg/kata/proc/types.go
+++ b/pkg/kata/proc/types.go
@@ -21,9 +21,16 @@ import (
 	"github.com/gogo/protobuf/types"
 )
 
+const (
+	// ErrContainerType represents the specific container type which does not exist
+	ErrContainerType = "the containerType does not exist"
+)
+
 // InitConfig hold task creation configuration
 type InitConfig struct {
 	ID       string
+	SandboxID     string
+	ContainerType string
 	Runtime  string
 	Rootfs   []mount.Mount
 	Terminal bool

--- a/pkg/kata/process.go
+++ b/pkg/kata/process.go
@@ -24,7 +24,6 @@ import (
 	"github.com/containerd/containerd/runtime"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	errors "github.com/pkg/errors"
-
 	"k8s.io/frakti/pkg/kata/proc"
 )
 
@@ -131,7 +130,7 @@ func (p *Process) Start(ctx context.Context) error {
 // Wait for the process to exit
 func (p *Process) Wait(ctx context.Context) (*runtime.Exit, error) {
 	init := p.t.processList[p.t.id]
-	init.Wait()
+	init.Wait(ctx)
 
 	return &runtime.Exit{
 		Timestamp: init.ExitedAt(),

--- a/pkg/kata/process.go
+++ b/pkg/kata/process.go
@@ -24,6 +24,8 @@ import (
 	"github.com/containerd/containerd/runtime"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	errors "github.com/pkg/errors"
+
+	"k8s.io/frakti/pkg/kata/proc"
 )
 
 // Process implements containerd.Process and containerd.State
@@ -112,7 +114,7 @@ func (p *Process) CloseIO(ctx context.Context) error {
 // Start the container's user defined process
 func (p *Process) Start(ctx context.Context) error {
 	process := p.t.processList[p.id]
-	err := process.Start(ctx)
+	err := process.(*proc.Init).Start(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "process start error")
 	}

--- a/pkg/kata/runtime.go
+++ b/pkg/kata/runtime.go
@@ -19,8 +19,11 @@ package kata
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
 	types "github.com/containerd/containerd/api/types"
@@ -28,6 +31,7 @@ import (
 	identifiers "github.com/containerd/containerd/identifiers"
 	log "github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
@@ -37,6 +41,10 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	errors "github.com/pkg/errors"
+
+	"github.com/containerd/containerd/runtime/kata/proc"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -89,6 +97,18 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 		events:  ic.Events,
 	}
 
+	tasks, err := r.restoreTasks(ic.Context)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: need to add the tasks to the monitor
+	for _, t := range tasks {
+		if err := r.tasks.AddWithNamespace(t.namespace, t); err != nil {
+			return nil, err
+		}
+	}
+
 	log.G(ic.Context).Infoln("Runtime: start containerd-kata plugin")
 
 	// TODO(ZeroMagic): reconnect the existing kata containers
@@ -109,6 +129,8 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 	if err != nil {
 		return nil, err
 	}
+
+	log.G(ctx).Infof("Runtime: Namespace is %s\n", namespace)
 
 	if err := identifiers.Validate(id); err != nil {
 		return nil, errors.Wrapf(err, "invalid task id")
@@ -149,29 +171,40 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 	}
 	spec := s.(*runtimespec.Spec)
 	containerType := spec.Annotations[annotations.ContainerType]
-	log.G(ctx).Infof("Runtime: ContainerType is %s\n", containerType)
+	log.G(ctx).Infof("Runtime: %s ContainerType is %s", id, containerType)
+	sandboxID := spec.Annotations[annotations.SandboxID]
 
 	// 6. new task. Init the vm, sandbox, and necessary container.
-	t, err := newTask(ctx, id, namespace, pid, r.monitor, r.events, opts, bundle)
+	t, err := newTask(id, namespace, pid, r.monitor, r.events)
 	if err != nil {
 		return nil, err
 	}
+	t.containerType = containerType
+	t.sandboxID = sandboxID
 
+	// 7. create sandbox or container
+	config := &proc.InitConfig{
+		ID:            id,
+		SandboxID:     sandboxID,
+		ContainerType: containerType,
+		Rootfs:        opts.Rootfs,
+		Terminal:      opts.IO.Terminal,
+		Stdin:         opts.IO.Stdin,
+		Stdout:        opts.IO.Stdout,
+		Stderr:        opts.IO.Stderr,
+	}
+	init, err := proc.NewInit(ctx, bundle.path, bundle.workDir, namespace, int(pid), config)
+	if err != nil {
+		return nil, errors.Wrap(err, "new init process error")
+	}
+	t.processList[id] = init
+
+	// 8. add the task to taskList
 	if err := r.tasks.Add(ctx, t); err != nil {
 		return nil, err
 	}
-	// 7. after the task is created, add it to the monitor if it has a cgroup
-	// this can be different on a checkpoint/restore
-	if t.cg != nil {
-		if err = r.monitor.Monitor(t); err != nil {
-			if _, err := r.Delete(ctx, t); err != nil {
-				log.G(ctx).WithError(err).Error("deleting task after failed monitor")
-			}
-			return nil, err
-		}
-	}
 
-	// 8. publish create event
+	// 9. publish create event
 	r.events.Publish(ctx, runtime.TaskCreateEventTopic, &eventstypes.TaskCreate{
 		ContainerID: id,
 		Bundle:      bundle.path,
@@ -202,7 +235,106 @@ func (r *Runtime) Tasks(ctx context.Context) ([]runtime.Task, error) {
 // Delete removes the task in the runtime.
 func (r *Runtime) Delete(ctx context.Context, t runtime.Task) (*runtime.Exit, error) {
 
-	// TODO(ZeroMagic): delete a task
+	// monitor will be handled
 
-	return nil, fmt.Errorf("not implemented")
+	taskID := t.ID()
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	bundle := loadBundle(
+		taskID,
+		filepath.Join(r.state, namespace, taskID),
+		filepath.Join(r.root, namespace, taskID),
+	)
+
+	// unmount
+	if err := mount.Unmount(filepath.Join(bundle.path, "rootfs"), 0); err != nil {
+		log.G(ctx).WithError(err).WithFields(logrus.Fields{
+			"path": bundle.path,
+			"id":   taskID,
+		}).Warnf("unmount task rootfs")
+	}
+
+	// delete process
+	p := t.(*Task).GetProcess(taskID)
+	if err := p.Delete(ctx); err != nil {
+		return nil, err
+	}
+
+	// remove the task
+	r.tasks.Delete(ctx, taskID)
+
+	// delete the bundle
+	if err := bundle.Delete(); err != nil {
+		log.G(ctx).WithError(err).Error("failed to delete bundle")
+	}
+
+	r.events.Publish(ctx, runtime.TaskDeleteEventTopic, &eventstypes.TaskDelete{
+		ContainerID: taskID,
+		Pid:         uint32(10244),
+		ExitStatus:  128 + uint32(unix.SIGKILL),
+		ExitedAt:    time.Now(),
+	})
+
+	return &runtime.Exit{
+		Pid:       uint32(p.Pid()),
+		Status:    uint32(p.ExitStatus()),
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func (r *Runtime) restoreTasks(ctx context.Context) ([]*Task, error) {
+	dir, err := ioutil.ReadDir(r.state)
+	if err != nil {
+		return nil, err
+	}
+	var o []*Task
+	for _, namespace := range dir {
+		if !namespace.IsDir() {
+			continue
+		}
+		name := namespace.Name()
+		log.G(ctx).WithField("namespace", name).Debug("loading tasks in namespace")
+		tasks, err := r.loadTasks(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, tasks...)
+	}
+	return o, nil
+}
+
+func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
+	dir, err := ioutil.ReadDir(filepath.Join(r.state, ns))
+	if err != nil {
+		return nil, err
+	}
+	var o []*Task
+	for _, path := range dir {
+		if !path.IsDir() {
+			continue
+		}
+		id := path.Name()
+		bundle := loadBundle(
+			id,
+			filepath.Join(r.state, ns, id),
+			filepath.Join(r.root, ns, id),
+		)
+		pidByte, _ := ioutil.ReadFile(filepath.Join(bundle.path, proc.InitPidFile))
+		pidStr := string(pidByte)
+		pid64, err := strconv.ParseInt(pidStr, 10, 32)
+		pid := uint32(pid64)
+
+		ctx = namespaces.WithNamespace(ctx, ns)
+
+		t, err := newTask(id, ns, pid, r.monitor, r.events)
+		if err != nil {
+			log.G(ctx).WithError(err).Error("loading task type")
+			continue
+		}
+		o = append(o, t)
+	}
+	return o, nil
 }

--- a/pkg/kata/runtime.go
+++ b/pkg/kata/runtime.go
@@ -41,10 +41,9 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	errors "github.com/pkg/errors"
-
-	"github.com/containerd/containerd/runtime/kata/proc"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+	"k8s.io/frakti/pkg/kata/proc"
 )
 
 const (

--- a/pkg/kata/server/container.go
+++ b/pkg/kata/server/container.go
@@ -33,19 +33,19 @@ import (
 // CreateContainer creates a kata-runtime container
 func CreateContainer(id, sandboxID string) (*vc.Sandbox, *vc.Container, error) {
 
-	criHosts := "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/"+sandboxID+"/hosts"
-	hosts := "/run/kata-containers/shared/sandboxes/"+sandboxID+"/"+id+"-hosts"
-	criResolv := "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/"+sandboxID+"/resolv.conf"
-	resolv := "/run/kata-containers/shared/sandboxes/"+sandboxID+"/"+id+"-resolv.conf"
+	criHosts := "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/" + sandboxID + "/hosts"
+	hosts := "/run/kata-containers/shared/sandboxes/" + sandboxID + "/" + id + "-hosts"
+	criResolv := "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/" + sandboxID + "/resolv.conf"
+	resolv := "/run/kata-containers/shared/sandboxes/" + sandboxID + "/" + id + "-resolv.conf"
 
 	command := exec.Command("cp", criHosts, hosts)
 	if err := command.Start(); err != nil {
-        fmt.Print(err)
+		fmt.Print(err)
 	}
 	command = exec.Command("cp", criResolv, resolv)
 	if err := command.Start(); err != nil {
-        fmt.Print(err)
-    }
+		fmt.Print(err)
+	}
 
 	configFile := "/run/containerd/io.containerd.runtime.v1.kata-runtime/k8s.io/" + id + "/config.json"
 	configJ, err := ioutil.ReadFile(configFile)
@@ -65,7 +65,6 @@ func CreateContainer(id, sandboxID string) (*vc.Sandbox, *vc.Container, error) {
 	str = strings.Replace(str, ",\"path\":\"/proc/10244/ns/uts\"", " ", -1)
 	str = strings.Replace(str, ",\"path\":\"/proc/10244/ns/net\"", " ", -1)
 
-	
 	logrus.FieldLogger(logrus.New()).WithFields(logrus.Fields{
 		"containerConfig": str,
 	}).Info("Container OCI Spec")
@@ -80,20 +79,20 @@ func CreateContainer(id, sandboxID string) (*vc.Sandbox, *vc.Container, error) {
 			annotations.BundlePathKey:    "/run/containerd/io.containerd.runtime.v1.kata-runtime/k8s.io/" + id,
 			annotations.ContainerTypeKey: string(vc.PodContainer),
 		},
-		Mounts: 	[]vc.Mount{
+		Mounts: []vc.Mount{
 			{
 				Source:      hosts,
 				Destination: "/etc/hosts",
 				Type:        "bind",
 				Options:     []string{"rbind", "rprivate", "rw"},
-				ReadOnly:	false,
+				ReadOnly:    false,
 			},
 			{
 				Source:      resolv,
 				Destination: "/etc/resolv.conf",
 				Type:        "bind",
 				Options:     []string{"rbind", "rprivate", "rw"},
-				ReadOnly:	false,
+				ReadOnly:    false,
 			},
 		},
 	}

--- a/pkg/kata/server/container.go
+++ b/pkg/kata/server/container.go
@@ -17,16 +17,17 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
 	"strings"
 	"syscall"
 
+	"github.com/containerd/containerd/runtime"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	errors "github.com/pkg/errors"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/kata/server/container.go
+++ b/pkg/kata/server/container.go
@@ -17,23 +17,107 @@ limitations under the License.
 package server
 
 import (
-	"context"
 	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
 	"syscall"
 
-	"github.com/containerd/containerd/runtime"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	errors "github.com/pkg/errors"
+
+	"github.com/sirupsen/logrus"
 )
 
 // CreateContainer creates a kata-runtime container
-func CreateContainer(ctx context.Context, id string, opts runtime.CreateOpts) error {
-	return fmt.Errorf("create container not implemented")
+func CreateContainer(id, sandboxID string) (*vc.Sandbox, *vc.Container, error) {
+
+	criHosts := "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/"+sandboxID+"/hosts"
+	hosts := "/run/kata-containers/shared/sandboxes/"+sandboxID+"/"+id+"-hosts"
+	criResolv := "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/"+sandboxID+"/resolv.conf"
+	resolv := "/run/kata-containers/shared/sandboxes/"+sandboxID+"/"+id+"-resolv.conf"
+
+	command := exec.Command("cp", criHosts, hosts)
+	if err := command.Start(); err != nil {
+        fmt.Print(err)
+	}
+	command = exec.Command("cp", criResolv, resolv)
+	if err := command.Start(); err != nil {
+        fmt.Print(err)
+    }
+
+	configFile := "/run/containerd/io.containerd.runtime.v1.kata-runtime/k8s.io/" + id + "/config.json"
+	configJ, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		fmt.Print(err)
+	}
+	str := string(configJ)
+	str = strings.Replace(str, "bounding", "Bounding", -1)
+	str = strings.Replace(str, "effective", "Effective", -1)
+	str = strings.Replace(str, "inheritable", "Inheritable", -1)
+	str = strings.Replace(str, "permitted", "Permitted", -1)
+	str = strings.Replace(str, "true", "true,\"Ambient\":null", -1)
+	str = strings.Replace(str, criHosts, hosts, -1)
+	str = strings.Replace(str, criResolv, resolv, -1)
+	str = strings.Replace(str, ",\"path\":\"/proc/10244/ns/pid\"", " ", -1)
+	str = strings.Replace(str, ",\"path\":\"/proc/10244/ns/ipc\"", " ", -1)
+	str = strings.Replace(str, ",\"path\":\"/proc/10244/ns/uts\"", " ", -1)
+	str = strings.Replace(str, ",\"path\":\"/proc/10244/ns/net\"", " ", -1)
+
+	
+	logrus.FieldLogger(logrus.New()).WithFields(logrus.Fields{
+		"containerConfig": str,
+	}).Info("Container OCI Spec")
+
+	// TODO: namespace would be solved
+	containerConfig := vc.ContainerConfig{
+		ID:     id,
+		RootFs: "/run/containerd/io.containerd.runtime.v1.kata-runtime/k8s.io/" + id + "/rootfs",
+		// Cmd:    cmd,
+		Annotations: map[string]string{
+			annotations.ConfigJSONKey:    str,
+			annotations.BundlePathKey:    "/run/containerd/io.containerd.runtime.v1.kata-runtime/k8s.io/" + id,
+			annotations.ContainerTypeKey: string(vc.PodContainer),
+		},
+		Mounts: 	[]vc.Mount{
+			{
+				Source:      hosts,
+				Destination: "/etc/hosts",
+				Type:        "bind",
+				Options:     []string{"rbind", "rprivate", "rw"},
+				ReadOnly:	false,
+			},
+			{
+				Source:      resolv,
+				Destination: "/etc/resolv.conf",
+				Type:        "bind",
+				Options:     []string{"rbind", "rprivate", "rw"},
+				ReadOnly:	false,
+			},
+		},
+	}
+
+	sandbox, container, err := vc.CreateContainer(sandboxID, containerConfig)
+	if err != nil {
+		logrus.FieldLogger(logrus.New()).Info("Create Container Failed:", err)
+		return nil, nil, errors.Wrapf(err, "Could not create container")
+	}
+
+	logrus.FieldLogger(logrus.New()).WithFields(logrus.Fields{
+		"container": container,
+	}).Info("Create Container Successfully")
+
+	return sandbox.(*vc.Sandbox), container.(*vc.Container), err
 }
 
 // StartContainer starts a kata-runtime container
-func StartContainer(ctx context.Context, id string, opts runtime.CreateOpts) error {
-	return fmt.Errorf("start container not implemented")
+func StartContainer(id, sandboxID string) (*vc.Container, error) {
+	container, err := vc.StartContainer(sandboxID, id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not start container")
+	}
+	return container.(*vc.Container), err
 }
 
 // StopContainer stops a kata-runtime container

--- a/pkg/kata/server/sandbox.go
+++ b/pkg/kata/server/sandbox.go
@@ -26,7 +26,6 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	errors "github.com/pkg/errors"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -228,9 +227,6 @@ func CreateSandbox(id string) (*vc.Sandbox, error) {
 		Annotations: map[string]string{
 			annotations.BundlePathKey: "/run/containerd/io.containerd.runtime.v1.kata-runtime/k8s.io/" + id,
 		},
-
-		ShmSize:    uint64(67108864),
-		SharePidNs: false,
 	}
 
 	sandbox, err := vc.CreateSandbox(sandboxConfig)

--- a/pkg/kata/task.go
+++ b/pkg/kata/task.go
@@ -201,7 +201,6 @@ func (t *Task) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runt
 	}, nil
 }
 
-
 // Pids returns all pids
 func (t *Task) Pids(ctx context.Context) ([]runtime.ProcessInfo, error) {
 	return nil, fmt.Errorf("task pids not implemented")
@@ -214,7 +213,17 @@ func (t *Task) Checkpoint(ctx context.Context, path string, options *types.Any) 
 
 // DeleteProcess deletes a specific exec process via its id
 func (t *Task) DeleteProcess(ctx context.Context, id string) (*runtime.Exit, error) {
-	return nil, fmt.Errorf("task delete process not implemented")
+	p := t.processList[t.id]
+	err := p.(*proc.ExecProcess).Delete(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "task DeleteProcess error")
+	}
+
+	return &runtime.Exit{
+		Pid:       uint32(p.Pid()),
+		Status:    uint32(p.ExitStatus()),
+		Timestamp: p.ExitedAt(),
+	}, nil
 }
 
 // Update sets the provided resources to a running task

--- a/pkg/kata/task.go
+++ b/pkg/kata/task.go
@@ -29,9 +29,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-
-	"github.com/containerd/containerd/runtime/kata/proc"
+	"k8s.io/frakti/pkg/kata/proc"
 )
 
 // Task on a hypervisor based system

--- a/vendor/github.com/kata-containers/agent/protocols/client/client.go
+++ b/vendor/github.com/kata-containers/agent/protocols/client/client.go
@@ -164,6 +164,7 @@ func agentDialer(addr *url.URL, enableYamux bool) dialer {
 
 // unix addr are parsed by grpc
 func unixDialer(sock string, timeout time.Duration) (net.Conn, error) {
+	sock = strings.Replace(sock, "unix://", "", 1)
 	return net.DialTimeout("unix", sock, timeout)
 }
 


### PR DESCRIPTION
### Sandbox

- run a new sandbox
- stop the sandbox

### Container

- create a new container
- start an existing container
- stop a running container

### Others

Here I modify unix addr which is parsed by grpc in vendor. Because containerd's grpc version is different from kata-runtime's grpc version. The version difference causes us to be unable to run the project.

