### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/vendor/github.com/ugorji/go/codec/test.py
+++ b/vendor/github.com/ugorji/go/codec/test.py
@@ -11,6 +11,7 @@
 
 # Ensure all "string" keys are utf strings (else encoded as bytes)
 
+from __future__ import print_function
 import cbor, msgpack, msgpackrpc, sys, os, threading
 
 def get_test_data_list():
@@ -34,7 +35,7 @@ def get_test_data_list():
          True,
          u"null",
          None,
-         u"someday",
+         u"some&day>some<day",
          1328176922000002000,
          u"",
          -2206187877999998000,
@@ -69,13 +70,11 @@ def build_test_data(destdir):
     for i in range(len(l)):
         # packer = msgpack.Packer()
         serialized = msgpack.dumps(l[i])
-        f = open(os.path.join(destdir, str(i) + '.msgpack.golden'), 'wb')
-        f.write(serialized)
-        f.close()
+        with open(os.path.join(destdir, str(i) + '.msgpack.golden'), 'wb') as f:
+            f.write(serialized)
         serialized = cbor.dumps(l[i])
-        f = open(os.path.join(destdir, str(i) + '.cbor.golden'), 'wb')
-        f.write(serialized)
-        f.close()
+        with open(os.path.join(destdir, str(i) + '.cbor.golden'), 'wb') as f:
+            f.write(serialized)
 
 def doRpcServer(port, stopTimeSec):
     class EchoHandler(object):
@@ -84,7 +83,7 @@ def doRpcServer(port, stopTimeSec):
         def EchoStruct(self, msg):
             return ("%s" % msg)
     
-    addr = msgpackrpc.Address('localhost', port)
+    addr = msgpackrpc.Address('127.0.0.1', port)
     server = msgpackrpc.Server(EchoHandler())
     server.listen(addr)
     # run thread to stop it after stopTimeSec seconds if > 0
@@ -96,17 +95,17 @@ def doRpcServer(port, stopTimeSec):
     server.start()
 
 def doRpcClientToPythonSvc(port):
-    address = msgpackrpc.Address('localhost', port)
+    address = msgpackrpc.Address('127.0.0.1', port)
     client = msgpackrpc.Client(address, unpack_encoding='utf-8')
-    print client.call("Echo123", "A1", "B2", "C3")
-    print client.call("EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"})
+    print(client.call("Echo123", "A1", "B2", "C3"))
+    print(client.call("EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"}))
    
 def doRpcClientToGoSvc(port):
-    # print ">>>> port: ", port, " <<<<<"
-    address = msgpackrpc.Address('localhost', port)
+    # print(">>>> port: ", port, " <<<<<")
+    address = msgpackrpc.Address('127.0.0.1', port)
     client = msgpackrpc.Client(address, unpack_encoding='utf-8')
-    print client.call("TestRpcInt.Echo123", ["A1", "B2", "C3"])
-    print client.call("TestRpcInt.EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"})
+    print(client.call("TestRpcInt.Echo123", ["A1", "B2", "C3"]))
+    print(client.call("TestRpcInt.EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"}))
 
 def doMain(args):
     if len(args) == 2 and args[0] == "testdata":
@@ -123,4 +122,3 @@ def doMain(args):
     
 if __name__ == "__main__":
     doMain(sys.argv[1:])
-


### PR DESCRIPTION
Resolves Python 3 syntax errors as discussed and merged in upstream: ugorji/go#309